### PR TITLE
Add project-grouped task overview to Relay

### DIFF
--- a/task-manager/CLAUDE.md
+++ b/task-manager/CLAUDE.md
@@ -9,7 +9,7 @@ Run app commands from this directory. Git commands can be run from here or from 
 
 Relay is currently a minimal web starter for task management with two primary ideas:
 
-- A compact task overview list
+- A compact task overview grouped by project
 - A selected-task drill-down for editing and agent activity
 - A thin top-menu shell that separates Tasks from Configuration
 
@@ -25,6 +25,7 @@ The current goal is to keep the product as small as possible before layering on 
 - `src/features/workspace/workspace-app.tsx`: app shell and state orchestration
 - `src/features/workspace/mock-data.ts`: local seed data for tasks and sample agent history
 - `src/features/workspace/operations.ts`: pure task and agent-call helpers
+- `src/features/workspace/task-grouping.ts`: lightweight project grouping helpers for the overview
 - `src/features/workspace/provider-api.ts`: provider request and response helpers
 - `src/features/workspace/task-overview.ts`: compact summary helpers for overview cards
 - `src/features/workspace/workspace-storage.ts`: workspace local storage helpers
@@ -38,7 +39,7 @@ Current focus:
 - Keep the app very small
 - Keep the top-level shell thin and desktop-oriented
 - Preserve add, edit, delete, task-level agent calls, and deletion of saved agent contributions
-- Keep the main overview compact and move agent history into task drill-down
+- Keep the main overview compact while grouping tasks by project and moving agent history into task drill-down
 - Keep configuration separate from the task workflow
 - Keep the agent model to one built-in path, not multiple agent types
 - Support local OpenAI configuration for real task-level agent calls first
@@ -50,4 +51,5 @@ Likely next tasks:
 - Add persistence beyond browser local storage when shared sync becomes important
 - Add completion state
 - Add ordering and filtering only if they are truly needed
+- Consider a normalized project model only if rename/canonicalization becomes important
 - Harden secret handling before any shared deployment

--- a/task-manager/README.md
+++ b/task-manager/README.md
@@ -6,11 +6,12 @@ This app lives in `task-manager/` inside the broader `productivity` git reposito
 
 ## Current Scope
 
-- One compact overview list holding all tasks
+- One compact overview grouped by project
 - One drill-down view for a selected task
 - A thin desktop top menu that switches between Tasks and Configuration
 - Add a task
 - Edit a task inside the drill-down
+- Assign an optional project to each task
 - Delete a task
 - Call one built-in agent from inside a task drill-down
 - Delete one saved agent contribution from a task drill-down
@@ -59,6 +60,7 @@ The app lives inside the existing git repository for this project.
 - `src/features/workspace/workspace-app.tsx`: app shell and state wiring for top-level views
 - `src/features/workspace/operations.ts`: pure task and agent-call updates
 - `src/features/workspace/mock-data.ts`: starter tasks and sample agent history
+- `src/features/workspace/task-grouping.ts`: project section helpers for the overview
 - `src/features/workspace/provider-api.ts`: shared provider request and response helpers
 - `src/features/workspace/task-overview.ts`: compact task-summary helpers for overview cards
 - `src/features/workspace/workspace-storage.ts`: workspace local storage helpers and normalization
@@ -77,5 +79,5 @@ The app lives inside the existing git repository for this project.
 
 - Add persistence beyond browser local storage when multi-device or shared access matters
 - Add task completion state
-- Add ordering, filtering, or grouping if needed
+- Add ordering or filtering if they are truly needed
 - Add stronger security around provider secrets before any shared deployment

--- a/task-manager/src/features/workspace/mock-data.ts
+++ b/task-manager/src/features/workspace/mock-data.ts
@@ -5,12 +5,14 @@ export const workspaceSeed: WorkspaceSnapshot = {
     {
       id: "task-1",
       title: "Define the smallest possible task manager",
+      project: "Relay foundation",
       details: "Keep only create, edit, delete, and call-agent actions.",
       agentCalls: [],
     },
     {
       id: "task-2",
       title: "List the next three product decisions",
+      project: "Product direction",
       details: "Use this as an example of a normal editable task.",
       agentCalls: [
         {

--- a/task-manager/src/features/workspace/operations.test.ts
+++ b/task-manager/src/features/workspace/operations.test.ts
@@ -16,12 +16,14 @@ describe("workspace operations", () => {
   it("adds a new task to the single task container", () => {
     const updatedWorkspace = addTask(workspaceSeed, {
       title: "Write Monday priorities",
+      project: "Weekly planning",
       details: "Keep it short and practical.",
     });
 
     expect(updatedWorkspace.tasks).toHaveLength(workspaceSeed.tasks.length + 1);
     expect(updatedWorkspace.tasks[0]).toMatchObject({
       title: "Write Monday priorities",
+      project: "Weekly planning",
       details: "Keep it short and practical.",
       agentCalls: [],
     });
@@ -34,11 +36,13 @@ describe("workspace operations", () => {
     const updatedWorkspace = updateTask(workspaceSeed, {
       taskId: "task-1",
       title: "Tighten the starter task manager",
+      project: "Relay foundation",
       details: "Only keep the features needed for a first pass.",
     });
 
     expect(updatedWorkspace.tasks.find((task) => task.id === "task-1")).toMatchObject({
       title: "Tighten the starter task manager",
+      project: "Relay foundation",
       details: "Only keep the features needed for a first pass.",
     });
   });
@@ -62,6 +66,7 @@ describe("workspace operations", () => {
     expect(updatedWorkspace.tasks.find((task) => task.id === "task-2")).toMatchObject({
       id: "task-2",
       title: "List the next three product decisions",
+      project: "Product direction",
       details: "Use this as an example of a normal editable task.",
       agentCalls: [],
     });

--- a/task-manager/src/features/workspace/operations.ts
+++ b/task-manager/src/features/workspace/operations.ts
@@ -17,6 +17,7 @@ export function addTask(
   const nextTask: Task = {
     id: buildNextTaskId(workspace.tasks),
     title: input.title.trim(),
+    project: input.project.trim(),
     details: input.details.trim(),
     agentCalls: [],
   };
@@ -41,6 +42,7 @@ export function updateTask(
         ? {
             ...task,
             title: input.title.trim(),
+            project: input.project.trim(),
             details: input.details.trim(),
           }
         : task,

--- a/task-manager/src/features/workspace/task-grouping.test.ts
+++ b/task-manager/src/features/workspace/task-grouping.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { workspaceSeed } from "./mock-data";
+import { buildTaskGroups, noProjectGroupLabel } from "./task-grouping";
+
+describe("task grouping", () => {
+  /**
+   * Keeps grouped overview sections stable while preserving the existing task order inside each group.
+   */
+  it("groups tasks by project without reordering tasks inside each section", () => {
+    const groups = buildTaskGroups([
+      {
+        ...workspaceSeed.tasks[0]!,
+        project: "Relay foundation",
+      },
+      {
+        ...workspaceSeed.tasks[1]!,
+        project: "Product direction",
+      },
+      {
+        ...workspaceSeed.tasks[0]!,
+        id: "task-3",
+        title: "Split overview into sections",
+        project: "Relay foundation",
+      },
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({
+      title: "Relay foundation",
+      taskCount: 2,
+    });
+    expect(groups[0]?.tasks.map((task) => task.id)).toEqual(["task-1", "task-3"]);
+    expect(groups[1]).toMatchObject({
+      title: "Product direction",
+      taskCount: 1,
+    });
+  });
+
+  /**
+   * Makes blank or missing project values visible instead of dropping those tasks from the overview.
+   */
+  it("collects blank project values into a fallback group", () => {
+    const groups = buildTaskGroups([
+      {
+        ...workspaceSeed.tasks[0]!,
+        project: "   ",
+      },
+    ]);
+
+    expect(groups).toEqual([
+      {
+        key: noProjectGroupLabel.toLowerCase(),
+        title: noProjectGroupLabel,
+        taskCount: 1,
+        tasks: [
+          {
+            ...workspaceSeed.tasks[0]!,
+            project: "   ",
+          },
+        ],
+      },
+    ]);
+  });
+
+  /**
+   * Prevents casing differences from splitting what is effectively the same project into multiple sections.
+   */
+  it("groups project names case-insensitively while preserving the first visible label", () => {
+    const groups = buildTaskGroups([
+      {
+        ...workspaceSeed.tasks[0]!,
+        project: "Relay foundation",
+      },
+      {
+        ...workspaceSeed.tasks[1]!,
+        project: "relay foundation",
+      },
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      key: "relay foundation",
+      title: "Relay foundation",
+      taskCount: 2,
+    });
+  });
+});

--- a/task-manager/src/features/workspace/task-grouping.ts
+++ b/task-manager/src/features/workspace/task-grouping.ts
@@ -1,0 +1,47 @@
+import { type Task } from "./types";
+
+export const noProjectGroupLabel = "No project";
+
+export interface TaskGroup {
+  key: string;
+  title: string;
+  taskCount: number;
+  tasks: Task[];
+}
+
+/**
+ * Builds lightweight project sections for the overview while keeping the source task list flat.
+ */
+export function buildTaskGroups(tasks: Task[]): TaskGroup[] {
+  const groupsByKey = new Map<string, TaskGroup>();
+
+  tasks.forEach((task) => {
+    const title = readProjectGroupTitle(task.project);
+    const key = title.toLocaleLowerCase();
+    const existingGroup = groupsByKey.get(key);
+
+    if (existingGroup) {
+      existingGroup.tasks.push(task);
+      existingGroup.taskCount += 1;
+      return;
+    }
+
+    groupsByKey.set(key, {
+      key,
+      title,
+      taskCount: 1,
+      tasks: [task],
+    });
+  });
+
+  return Array.from(groupsByKey.values());
+}
+
+/**
+ * Normalizes empty project values into a visible fallback section label.
+ */
+function readProjectGroupTitle(project: string) {
+  const normalizedProject = project.trim();
+
+  return normalizedProject || noProjectGroupLabel;
+}

--- a/task-manager/src/features/workspace/task-management-view.tsx
+++ b/task-manager/src/features/workspace/task-management-view.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { FormattedAgentResponse } from "@/features/workspace/formatted-agent-response";
 import { getProviderLabel } from "@/features/workspace/provider-config";
+import { buildTaskGroups, noProjectGroupLabel } from "@/features/workspace/task-grouping";
 import { buildTaskOverviewSummary } from "@/features/workspace/task-overview";
 import { type AgentCallStatus, type AgentDraft, type Task } from "@/features/workspace/types";
 
@@ -16,9 +17,11 @@ interface TaskManagementViewProps {
   selectedTask: Task | null;
   selectedAgentDraft: AgentDraft;
   newTaskTitle: string;
+  newTaskProject: string;
   newTaskDetails: string;
   editingTaskId: string | null;
   editTitle: string;
+  editProject: string;
   editDetails: string;
   openAgentTaskId: string | null;
   pendingTaskId: string | null;
@@ -26,6 +29,7 @@ interface TaskManagementViewProps {
   activeProviderModel: string;
   isActiveProviderReady: boolean;
   onSetNewTaskTitle: (value: string) => void;
+  onSetNewTaskProject: (value: string) => void;
   onSetNewTaskDetails: (value: string) => void;
   onAddTask: () => void;
   onOpenTask: (taskId: string) => void;
@@ -37,6 +41,7 @@ interface TaskManagementViewProps {
   onDeleteAgentContribution: (taskId: string, agentCallId: string) => void;
   onToggleAgentPanel: (taskId: string) => void;
   onSetEditTitle: (value: string) => void;
+  onSetEditProject: (value: string) => void;
   onSetEditDetails: (value: string) => void;
   onCloseAgentPanel: () => void;
   onAgentBriefChange: (taskId: string, brief: string) => void;
@@ -51,9 +56,11 @@ export function TaskManagementView({
   selectedTask,
   selectedAgentDraft,
   newTaskTitle,
+  newTaskProject,
   newTaskDetails,
   editingTaskId,
   editTitle,
+  editProject,
   editDetails,
   openAgentTaskId,
   pendingTaskId,
@@ -61,6 +68,7 @@ export function TaskManagementView({
   activeProviderModel,
   isActiveProviderReady,
   onSetNewTaskTitle,
+  onSetNewTaskProject,
   onSetNewTaskDetails,
   onAddTask,
   onOpenTask,
@@ -72,6 +80,7 @@ export function TaskManagementView({
   onDeleteAgentContribution,
   onToggleAgentPanel,
   onSetEditTitle,
+  onSetEditProject,
   onSetEditDetails,
   onCloseAgentPanel,
   onAgentBriefChange,
@@ -85,8 +94,8 @@ export function TaskManagementView({
             <p className="text-sm text-[color:var(--muted)]">Bare-bones starter</p>
             <h1 className="mt-2 text-3xl font-semibold">Tasks</h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--muted)]">
-              One list for all tasks. Add, edit, delete, and send a task to one built-in
-              agent while keeping configuration in its own separate view.
+              Keep one lightweight workspace for all tasks, but scan them in project
+              groups before opening a focused drill-down.
             </p>
           </div>
 
@@ -118,6 +127,11 @@ export function TaskManagementView({
             placeholder="Task title"
             value={newTaskTitle}
           />
+          <Input
+            onChange={(event) => onSetNewTaskProject(event.target.value)}
+            placeholder="Project (optional)"
+            value={newTaskProject}
+          />
           <Textarea
             onChange={(event) => onSetNewTaskDetails(event.target.value)}
             placeholder="Optional task details"
@@ -141,7 +155,7 @@ export function TaskManagementView({
             <p className="mt-1 max-w-2xl text-sm leading-6 text-[color:var(--muted)]">
               {selectedTask
                 ? "Editing and agent activity live here so the main overview can stay compact."
-                : "Scan tasks in a lightweight overview, then open one when you want the full task context and agent history."}
+                : "Scan tasks in lightweight project sections, then open one when you want the full task context and agent history."}
             </p>
           </div>
           <Badge variant={selectedTask ? "accent" : "neutral"}>
@@ -155,6 +169,7 @@ export function TaskManagementView({
             activeProviderModel={activeProviderModel}
             agentDraft={selectedAgentDraft}
             editDetails={editDetails}
+            editProject={editProject}
             editingTaskId={editingTaskId}
             editTitle={editTitle}
             onAgentBriefChange={onAgentBriefChange}
@@ -166,6 +181,7 @@ export function TaskManagementView({
             onReturnToOverview={onReturnToOverview}
             onSaveEdit={onSaveEdit}
             onSetEditDetails={onSetEditDetails}
+            onSetEditProject={onSetEditProject}
             onSetEditTitle={onSetEditTitle}
             onStartEdit={onStartEdit}
             onToggleAgentPanel={onToggleAgentPanel}
@@ -196,21 +212,44 @@ function TaskOverviewList({ tasks, onOpenTask, onDeleteTask }: TaskOverviewListP
       <div className="mt-4 rounded-lg border border-dashed border-[color:var(--border)] bg-[color:var(--surface)] p-6 text-center">
         <p className="text-sm font-medium">No tasks yet</p>
         <p className="mt-2 text-sm leading-6 text-[color:var(--muted)]">
-          Add your first task above and it will appear here as a compact overview card.
+          Add your first task above and it will appear in the matching project section.
         </p>
       </div>
     );
   }
 
+  const taskGroups = buildTaskGroups(tasks);
+
   return (
-    <div className="mt-4 space-y-3">
-      {tasks.map((task) => (
-        <TaskOverviewCard
-          key={task.id}
-          onDeleteTask={onDeleteTask}
-          onOpenTask={onOpenTask}
-          task={task}
-        />
+    <div className="mt-4 space-y-4">
+      {taskGroups.map((taskGroup) => (
+        <section
+          className="rounded-xl border border-[color:var(--border)] bg-[color:var(--surface)] p-4"
+          key={taskGroup.key}
+        >
+          <div className="flex flex-col gap-2 border-b border-[color:var(--border)] pb-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
+                Project
+              </p>
+              <h2 className="mt-1 text-lg font-medium">{taskGroup.title}</h2>
+            </div>
+            <Badge variant={taskGroup.title === noProjectGroupLabel ? "neutral" : "accent"}>
+              {readTaskCountLabel(taskGroup.taskCount)}
+            </Badge>
+          </div>
+
+          <div className="mt-3 space-y-3">
+            {taskGroup.tasks.map((task) => (
+              <TaskOverviewCard
+                key={task.id}
+                onDeleteTask={onDeleteTask}
+                onOpenTask={onOpenTask}
+                task={task}
+              />
+            ))}
+          </div>
+        </section>
       ))}
     </div>
   );
@@ -227,17 +266,19 @@ interface TaskOverviewCardProps {
  */
 function TaskOverviewCard({ task, onOpenTask, onDeleteTask }: TaskOverviewCardProps) {
   const taskOverview = buildTaskOverviewSummary(task);
+  const hasProject = Boolean(task.project.trim());
 
   return (
-    <article className="rounded-xl border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
+    <article className="rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)] p-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h2 className="text-lg font-medium">{task.title}</h2>
+          <h3 className="text-lg font-medium">{task.title}</h3>
           <p className="mt-2 text-sm leading-6 text-[color:var(--muted)]">
             {taskOverview.detailsPreview}
           </p>
 
           <div className="mt-3 flex flex-wrap gap-2">
+            {hasProject ? <Badge variant="accent">{task.project.trim()}</Badge> : null}
             <Badge variant="neutral">{readAgentActivityLabel(taskOverview.agentCallCount)}</Badge>
             {taskOverview.latestAgentStatus ? (
               <Badge variant={readAgentStatusBadgeVariant(taskOverview.latestAgentStatus)}>
@@ -269,6 +310,7 @@ interface TaskDrillDownProps {
   task: Task;
   editingTaskId: string | null;
   editTitle: string;
+  editProject: string;
   editDetails: string;
   openAgentTaskId: string | null;
   pendingTaskId: string | null;
@@ -283,6 +325,7 @@ interface TaskDrillDownProps {
   onDeleteTask: (taskId: string) => void;
   onToggleAgentPanel: (taskId: string) => void;
   onSetEditTitle: (value: string) => void;
+  onSetEditProject: (value: string) => void;
   onSetEditDetails: (value: string) => void;
   onCloseAgentPanel: () => void;
   onAgentBriefChange: (taskId: string, brief: string) => void;
@@ -296,6 +339,7 @@ function TaskDrillDown({
   task,
   editingTaskId,
   editTitle,
+  editProject,
   editDetails,
   openAgentTaskId,
   pendingTaskId,
@@ -310,6 +354,7 @@ function TaskDrillDown({
   onDeleteTask,
   onToggleAgentPanel,
   onSetEditTitle,
+  onSetEditProject,
   onSetEditDetails,
   onCloseAgentPanel,
   onAgentBriefChange,
@@ -332,6 +377,11 @@ function TaskDrillDown({
           <p className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
             Task drill-down
           </p>
+          {task.project.trim() ? (
+            <p className="mt-2 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
+              Project · {task.project.trim()}
+            </p>
+          ) : null}
           <h2 className="mt-2 text-2xl font-semibold">{task.title}</h2>
           <p className="mt-3 text-sm leading-6 text-[color:var(--muted)]">
             {task.details || "No details yet."}
@@ -381,6 +431,11 @@ function TaskDrillDown({
               onChange={(event) => onSetEditTitle(event.target.value)}
               placeholder="Task title"
               value={editTitle}
+            />
+            <Input
+              onChange={(event) => onSetEditProject(event.target.value)}
+              placeholder="Project (optional)"
+              value={editProject}
             />
             <Textarea
               onChange={(event) => onSetEditDetails(event.target.value)}

--- a/task-manager/src/features/workspace/types.ts
+++ b/task-manager/src/features/workspace/types.ts
@@ -31,6 +31,7 @@ export interface AgentCall {
 export interface Task {
   id: string;
   title: string;
+  project: string;
   details: string;
   agentCalls: AgentCall[];
 }
@@ -41,12 +42,14 @@ export interface WorkspaceSnapshot {
 
 export interface AddTaskInput {
   title: string;
+  project: string;
   details: string;
 }
 
 export interface UpdateTaskInput {
   taskId: string;
   title: string;
+  project: string;
   details: string;
 }
 

--- a/task-manager/src/features/workspace/workspace-app.tsx
+++ b/task-manager/src/features/workspace/workspace-app.tsx
@@ -46,10 +46,12 @@ export function WorkspaceApp() {
   const [activeView, setActiveView] = useState(createDefaultWorkspaceView);
   const [isTopMenuExpanded, setIsTopMenuExpanded] = useState(false);
   const [newTaskTitle, setNewTaskTitle] = useState("");
+  const [newTaskProject, setNewTaskProject] = useState("");
   const [newTaskDetails, setNewTaskDetails] = useState("");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
+  const [editProject, setEditProject] = useState("");
   const [editDetails, setEditDetails] = useState("");
   const [openAgentTaskId, setOpenAgentTaskId] = useState<string | null>(null);
   const [agentDrafts, setAgentDrafts] = useState<Record<string, AgentDraft>>({});
@@ -154,10 +156,12 @@ export function WorkspaceApp() {
     setWorkspace((currentWorkspace) =>
       addTask(currentWorkspace, {
         title: newTaskTitle,
+        project: newTaskProject,
         details: newTaskDetails,
       }),
     );
     setNewTaskTitle("");
+    setNewTaskProject("");
     setNewTaskDetails("");
   }
 
@@ -198,6 +202,7 @@ export function WorkspaceApp() {
     setSelectedTaskId(task.id);
     setEditingTaskId(task.id);
     setEditTitle(task.title);
+    setEditProject(task.project);
     setEditDetails(task.details);
   }
 
@@ -213,11 +218,13 @@ export function WorkspaceApp() {
       updateTask(currentWorkspace, {
         taskId,
         title: editTitle,
+        project: editProject,
         details: editDetails,
       }),
     );
     setEditingTaskId(null);
     setEditTitle("");
+    setEditProject("");
     setEditDetails("");
   }
 
@@ -227,6 +234,7 @@ export function WorkspaceApp() {
   function handleCancelEdit() {
     setEditingTaskId(null);
     setEditTitle("");
+    setEditProject("");
     setEditDetails("");
   }
 
@@ -509,10 +517,12 @@ export function WorkspaceApp() {
               activeProviderLabel={activeProviderLabel}
               activeProviderModel={activeProviderSettings.model}
               editDetails={editDetails}
+              editProject={editProject}
               editingTaskId={editingTaskId}
               editTitle={editTitle}
               isActiveProviderReady={isActiveProviderReady}
               newTaskDetails={newTaskDetails}
+              newTaskProject={newTaskProject}
               newTaskTitle={newTaskTitle}
               onAddTask={handleAddTask}
               onAgentBriefChange={handleAgentBriefChange}
@@ -525,8 +535,10 @@ export function WorkspaceApp() {
               onReturnToOverview={handleReturnToOverview}
               onSaveEdit={handleSaveEdit}
               onSetEditDetails={setEditDetails}
+              onSetEditProject={setEditProject}
               onSetEditTitle={setEditTitle}
               onSetNewTaskDetails={setNewTaskDetails}
+              onSetNewTaskProject={setNewTaskProject}
               onSetNewTaskTitle={setNewTaskTitle}
               onStartEdit={handleStartEdit}
               onToggleAgentPanel={handleToggleAgentPanel}

--- a/task-manager/src/features/workspace/workspace-storage.test.ts
+++ b/task-manager/src/features/workspace/workspace-storage.test.ts
@@ -40,6 +40,7 @@ describe("workspace storage", () => {
         {
           id: "task-custom",
           title: "Follow up with daycare",
+          project: "Family admin",
           details: 123,
           agentCalls: [
             {
@@ -67,6 +68,7 @@ describe("workspace storage", () => {
     expect(workspace.tasks[0]).toMatchObject({
       id: "task-custom",
       title: "Follow up with daycare",
+      project: "Family admin",
       details: "",
     });
     expect(workspace.tasks[0]?.agentCalls[0]).toMatchObject({
@@ -86,5 +88,23 @@ describe("workspace storage", () => {
       status: "error",
       createdAt: "Unknown time",
     });
+  });
+
+  /**
+   * Keeps older saved tasks visible by defaulting the new project field to a blank value.
+   */
+  it("defaults missing project data to an empty string", () => {
+    const workspace = normalizeWorkspaceSnapshot({
+      tasks: [
+        {
+          id: "task-custom",
+          title: "Follow up with daycare",
+          details: "Ask about the new pickup flow.",
+          agentCalls: [],
+        },
+      ],
+    });
+
+    expect(workspace.tasks[0]?.project).toBe("");
   });
 });

--- a/task-manager/src/features/workspace/workspace-storage.ts
+++ b/task-manager/src/features/workspace/workspace-storage.ts
@@ -53,6 +53,7 @@ function normalizeTask(value: unknown, index: number): Task | null {
   return {
     id: readString(value.id) || `task-${index + 1}`,
     title: readString(value.title) || "Untitled task",
+    project: readString(value.project),
     details: readString(value.details),
     agentCalls: Array.isArray(value.agentCalls)
       ? value.agentCalls.flatMap((agentCall, agentCallIndex) => {


### PR DESCRIPTION
## Summary
- add an optional project field to Relay tasks and preserve it through local storage normalization
- group the task overview into lightweight project sections using a pure helper while keeping drill-down behavior task-centric
- update tests and task-manager docs to cover project grouping and backward compatibility

## Verification
- npm test -- --run
- npm run lint
- npm run build

Closes #1