### PR TITLE
feat: implement minimalist line-item task overview UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ yarn-error.log*
 .env*
 *.csv
 *.xlsx
+input/
+output/
 
 # vercel
 task-manager/.vercel

--- a/task-manager/src/app/globals.css
+++ b/task-manager/src/app/globals.css
@@ -8,6 +8,9 @@
   --surface-muted: #f4f4f5;
   --border: #d4d4d8;
   --border-strong: #a1a1aa;
+  --row-divider: #e4e4e7;
+  --row-hover: #f9fafb;
+  --row-active: #f4f4f5;
   --muted: #71717a;
   --muted-strong: #3f3f46;
   --accent: #18181b;

--- a/task-manager/src/features/workspace/task-management-view.test.tsx
+++ b/task-manager/src/features/workspace/task-management-view.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { workspaceSeed } from "./mock-data";
+import { TaskManagementView } from "./task-management-view";
+
+function buildTaskManagementViewProps() {
+  return {
+    tasks: workspaceSeed.tasks,
+    selectedTask: null,
+    selectedAgentDraft: {
+      brief: "",
+      error: null,
+    },
+    newTaskTitle: "",
+    newTaskDetails: "",
+    editingTaskId: null,
+    editTitle: "",
+    editDetails: "",
+    openAgentTaskId: null,
+    pendingTaskId: null,
+    activeProviderLabel: "OpenAI",
+    activeProviderModel: "gpt-5",
+    isActiveProviderReady: true,
+    onSetNewTaskTitle: vi.fn(),
+    onSetNewTaskDetails: vi.fn(),
+    onAddTask: vi.fn(),
+    onOpenTask: vi.fn(),
+    onDeleteTask: vi.fn(),
+    onReturnToOverview: vi.fn(),
+    onStartEdit: vi.fn(),
+    onSaveEdit: vi.fn(),
+    onCancelEdit: vi.fn(),
+    onDeleteAgentContribution: vi.fn(),
+    onToggleAgentPanel: vi.fn(),
+    onSetEditTitle: vi.fn(),
+    onSetEditDetails: vi.fn(),
+    onCloseAgentPanel: vi.fn(),
+    onAgentBriefChange: vi.fn(),
+    onCallAgent: vi.fn(),
+  };
+}
+
+describe("task management view", () => {
+  /**
+   * Keeps the overview in a Things-like line-item format instead of boxed cards.
+   */
+  it("renders task rows as minimalist line items", () => {
+    const markup = renderToStaticMarkup(<TaskManagementView {...buildTaskManagementViewProps()} />);
+
+    expect(markup).toContain("task-overview-line-list");
+    expect(markup).toContain("task-overview-line-item");
+  });
+});

--- a/task-manager/src/features/workspace/task-management-view.tsx
+++ b/task-manager/src/features/workspace/task-management-view.tsx
@@ -102,7 +102,7 @@ export function TaskManagementView({
       </header>
 
       {!isActiveProviderReady ? (
-        <section className="mt-6 rounded-xl border border-dashed border-amber-200 bg-amber-50 p-4 text-amber-900">
+        <section className="mt-6 border-l-2 border-amber-300 bg-amber-50/80 px-4 py-3 text-amber-900">
           <p className="text-sm font-medium">Live agent calls need configuration first</p>
           <p className="mt-2 max-w-2xl text-sm leading-6">
             Task editing already works, but live agent calls will stay unavailable until
@@ -111,8 +111,8 @@ export function TaskManagementView({
         </section>
       ) : null}
 
-      <section className="mt-6 rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)] p-4">
-        <div className="grid gap-3">
+      <section className="mt-6 border-b border-[color:var(--row-divider)] pb-6">
+        <div className="grid max-w-2xl gap-3">
           <Input
             onChange={(event) => onSetNewTaskTitle(event.target.value)}
             placeholder="Task title"
@@ -132,7 +132,7 @@ export function TaskManagementView({
         </div>
       </section>
 
-      <section className="mt-6 rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)] p-4">
+      <section className="mt-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className="text-sm font-medium">
@@ -193,75 +193,70 @@ interface TaskOverviewListProps {
 function TaskOverviewList({ tasks, onOpenTask, onDeleteTask }: TaskOverviewListProps) {
   if (tasks.length === 0) {
     return (
-      <div className="mt-4 rounded-lg border border-dashed border-[color:var(--border)] bg-[color:var(--surface)] p-6 text-center">
+      <div className="task-overview-empty mt-6 py-8 text-center">
         <p className="text-sm font-medium">No tasks yet</p>
         <p className="mt-2 text-sm leading-6 text-[color:var(--muted)]">
-          Add your first task above and it will appear here as a compact overview card.
+          Add your first task above and it will appear as a simple line item.
         </p>
       </div>
     );
   }
 
   return (
-    <div className="mt-4 space-y-3">
+    <ul className="task-overview-line-list mt-4 divide-y divide-[color:var(--row-divider)] border-y border-[color:var(--row-divider)]">
       {tasks.map((task) => (
-        <TaskOverviewCard
+        <TaskOverviewRow
           key={task.id}
           onDeleteTask={onDeleteTask}
           onOpenTask={onOpenTask}
           task={task}
         />
       ))}
-    </div>
+    </ul>
   );
 }
 
-interface TaskOverviewCardProps {
+interface TaskOverviewRowProps {
   task: Task;
   onOpenTask: (taskId: string) => void;
   onDeleteTask: (taskId: string) => void;
 }
 
 /**
- * Shows the light task summary used in the main overview list.
+ * Shows each task as a lightweight line item so scanning stays fast.
  */
-function TaskOverviewCard({ task, onOpenTask, onDeleteTask }: TaskOverviewCardProps) {
+function TaskOverviewRow({ task, onOpenTask, onDeleteTask }: TaskOverviewRowProps) {
   const taskOverview = buildTaskOverviewSummary(task);
+  const latestStatusText = taskOverview.latestAgentStatus
+    ? readLatestAgentStatusLabel(taskOverview.latestAgentStatus)
+    : null;
 
   return (
-    <article className="rounded-xl border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+    <li className="task-overview-line-item py-3 transition-colors hover:bg-[color:var(--row-hover)] sm:py-4">
+      <div className="flex flex-col gap-3 px-1 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h2 className="text-lg font-medium">{task.title}</h2>
-          <p className="mt-2 text-sm leading-6 text-[color:var(--muted)]">
+          <h2 className="text-base font-medium sm:text-lg">{task.title}</h2>
+          <p className="mt-1 text-sm leading-6 text-[color:var(--muted)]">
             {taskOverview.detailsPreview}
           </p>
-
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Badge variant="neutral">{readAgentActivityLabel(taskOverview.agentCallCount)}</Badge>
-            {taskOverview.latestAgentStatus ? (
-              <Badge variant={readAgentStatusBadgeVariant(taskOverview.latestAgentStatus)}>
-                {readLatestAgentStatusLabel(taskOverview.latestAgentStatus)}
-              </Badge>
-            ) : null}
-          </div>
-
-          {taskOverview.latestAgentTimestamp ? (
-            <p className="mt-2 text-xs text-[color:var(--muted)]">
-              Latest activity {taskOverview.latestAgentTimestamp}
-            </p>
-          ) : null}
+          <p className="mt-2 text-xs text-[color:var(--muted)]">
+            {readAgentActivityLabel(taskOverview.agentCallCount)}
+            {latestStatusText ? ` · ${latestStatusText}` : ""}
+            {taskOverview.latestAgentTimestamp ? ` · ${taskOverview.latestAgentTimestamp}` : ""}
+          </p>
         </div>
 
-        <div className="flex flex-wrap gap-2 sm:justify-end">
-          <Button onClick={() => onOpenTask(task.id)}>Open task</Button>
-          <Button onClick={() => onDeleteTask(task.id)} variant="outline">
+        <div className="flex min-h-11 shrink-0 items-center gap-1 sm:justify-end">
+          <Button onClick={() => onOpenTask(task.id)} size="sm" variant="ghost">
+            Open
+          </Button>
+          <Button onClick={() => onDeleteTask(task.id)} size="sm" variant="ghost">
             <Trash2 className="size-4" />
-            Delete
+            Remove
           </Button>
         </div>
       </div>
-    </article>
+    </li>
   );
 }
 

--- a/task-manager/src/features/workspace/workspace-top-menu.test.tsx
+++ b/task-manager/src/features/workspace/workspace-top-menu.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkspaceTopMenu } from "./workspace-top-menu";
+
+describe("workspace top menu", () => {
+  /**
+   * Keeps the shell chrome intentionally light for the minimalist task workspace.
+   */
+  it("renders the lightweight top-menu shell class", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceTopMenu
+        activeView="tasks"
+        isExpanded={false}
+        onSelectView={vi.fn()}
+        onToggleMenu={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("workspace-top-menu-shell");
+  });
+});

--- a/task-manager/src/features/workspace/workspace-top-menu.tsx
+++ b/task-manager/src/features/workspace/workspace-top-menu.tsx
@@ -30,7 +30,7 @@ export function WorkspaceTopMenu({
   onToggleMenu,
 }: WorkspaceTopMenuProps) {
   return (
-    <section className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] px-4 py-3">
+    <section className="workspace-top-menu-shell border-b border-[color:var(--border)] px-1 pb-3">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--muted)]">

--- a/task-manager/vitest.config.ts
+++ b/task-manager/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Keeps Vitest module resolution aligned with the app's `@/` import alias.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- refactor task overview from boxed cards to minimalist line-item rows with subtle dividers and compact metadata
- flatten task workflow chrome and lighten the top menu shell while preserving add/edit/delete/agent flows
- add focused UI tests for line-item and top-menu shell markers, and add Vitest alias config for `@/` imports
- update `.gitignore` to include `input/` and `output/` patterns for pre-push safety compliance

## Test Plan
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`

Closes #3
