### PR TITLE
Implement Command+K global search popup MVP

### DIFF
--- a/src/features/workspace/global-search-dialog.test.tsx
+++ b/src/features/workspace/global-search-dialog.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildGlobalSearchResults } from "./global-search";
+import { GlobalSearchDialog } from "./global-search-dialog";
+import { workspaceSeed } from "./mock-data";
+
+describe("global search dialog", () => {
+  /**
+   * Ensures the dialog shows mixed result labels and parent context so similarly named items
+   * remain understandable in the MVP.
+   */
+  it("renders labeled mixed results with contextual metadata", () => {
+    const markup = renderToStaticMarkup(
+      <GlobalSearchDialog
+        activeIndex={0}
+        isOpen
+        onActiveIndexChange={vi.fn()}
+        onClose={vi.fn()}
+        onQueryChange={vi.fn()}
+        onSelectResult={vi.fn()}
+        query=""
+        results={buildGlobalSearchResults(workspaceSeed)}
+      />,
+    );
+
+    expect(markup).toContain("Task");
+    expect(markup).toContain("Project");
+    expect(markup).toContain("Initiative");
+    expect(markup).toContain("Project: Relay MVP");
+    expect(markup).toContain("Q2 Product Launch");
+  });
+
+  /**
+   * Keeps the empty state explicit when the current query has no matches.
+   */
+  it("renders a helpful empty state when there are no matches", () => {
+    const markup = renderToStaticMarkup(
+      <GlobalSearchDialog
+        activeIndex={0}
+        isOpen
+        onActiveIndexChange={vi.fn()}
+        onClose={vi.fn()}
+        onQueryChange={vi.fn()}
+        onSelectResult={vi.fn()}
+        query="missing result"
+        results={[]}
+      />,
+    );
+
+    expect(markup).toContain("No matches for");
+    expect(markup).toContain("missing result");
+  });
+});

--- a/src/features/workspace/global-search-dialog.tsx
+++ b/src/features/workspace/global-search-dialog.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { type KeyboardEvent } from "react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import {
+  cycleGlobalSearchIndex,
+  readGlobalSearchEntityLabel,
+  type GlobalSearchResult,
+} from "./global-search";
+
+interface GlobalSearchDialogProps {
+  isOpen: boolean;
+  query: string;
+  results: GlobalSearchResult[];
+  activeIndex: number;
+  onActiveIndexChange: (nextIndex: number) => void;
+  onClose: () => void;
+  onQueryChange: (nextQuery: string) => void;
+  onSelectResult: (result: GlobalSearchResult) => void;
+}
+
+/**
+ * Renders the lightweight global search overlay while delegating business data and navigation
+ * decisions back to the app shell.
+ */
+export function GlobalSearchDialog({
+  isOpen,
+  query,
+  results,
+  activeIndex,
+  onActiveIndexChange,
+  onClose,
+  onQueryChange,
+  onSelectResult,
+}: GlobalSearchDialogProps) {
+  const activeResult =
+    activeIndex >= 0 && activeIndex < results.length ? results[activeIndex] : null;
+
+  if (!isOpen) {
+    return null;
+  }
+
+  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      onActiveIndexChange(cycleGlobalSearchIndex(activeIndex, "next", results.length));
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      onActiveIndexChange(cycleGlobalSearchIndex(activeIndex, "previous", results.length));
+      return;
+    }
+
+    if (event.key === "Enter" && activeResult) {
+      event.preventDefault();
+      onSelectResult(activeResult);
+    }
+  }
+
+  return (
+    <div
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/35 px-4 py-12"
+      onClick={onClose}
+      role="dialog"
+    >
+      <div
+        className="w-full max-w-2xl overflow-hidden rounded-xl border border-[color:var(--border)] bg-[color:var(--surface)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="border-b border-[color:var(--border)] p-3">
+          <Input
+            aria-label="Global search"
+            autoFocus
+            onChange={(event) => onQueryChange(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Search tasks, projects, and initiatives..."
+            value={query}
+          />
+        </div>
+
+        <div className="max-h-[24rem] overflow-y-auto p-2">
+          {results.length === 0 ? (
+            <p className="rounded-md px-3 py-6 text-sm text-[color:var(--muted)]">
+              {query.trim()
+                ? `No matches for "${query.trim()}".`
+                : "No searchable items yet."}
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {results.map((result, index) => (
+                <li key={`${result.entityType}-${result.id}`}>
+                  <button
+                    className={cn(
+                      "w-full rounded-lg border px-3 py-3 text-left transition",
+                      activeIndex === index
+                        ? "border-[color:var(--foreground)] bg-[color:var(--surface-strong)]"
+                        : "border-transparent hover:border-[color:var(--border)] hover:bg-[color:var(--surface-strong)]",
+                    )}
+                    onClick={() => onSelectResult(result)}
+                    onMouseEnter={() => onActiveIndexChange(index)}
+                    type="button"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-[color:var(--foreground)]">
+                          {result.title}
+                        </p>
+                        {result.description ? (
+                          <p className="mt-1 line-clamp-2 text-sm text-[color:var(--muted)]">
+                            {result.description}
+                          </p>
+                        ) : null}
+                        <p className="mt-2 text-xs text-[color:var(--muted)]">
+                          {result.contextLabel}
+                        </p>
+                      </div>
+                      <span className="rounded-full border border-[color:var(--border)] px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-[color:var(--muted-strong)]">
+                        {readGlobalSearchEntityLabel(result.entityType)}
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="border-t border-[color:var(--border)] px-3 py-2 text-xs text-[color:var(--muted)]">
+          Use <kbd>↑</kbd> <kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to open, and <kbd>Esc</kbd>{" "}
+          to close.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/workspace/global-search.test.ts
+++ b/src/features/workspace/global-search.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import { workspaceSeed } from "./mock-data";
+import {
+  buildGlobalSearchResults,
+  cycleGlobalSearchIndex,
+  filterGlobalSearchResults,
+  readGlobalSearchEntityLabel,
+  resolveGlobalSearchSelection,
+} from "./global-search";
+
+/**
+ * Keeps the command search tests grounded in the same starter workspace data the app renders.
+ */
+function buildSeedResults() {
+  return buildGlobalSearchResults(workspaceSeed);
+}
+
+describe("global search", () => {
+  /**
+   * Ensures the dialog can search across all supported workspace entity types.
+   */
+  it("builds searchable results for tasks, projects, and initiatives", () => {
+    const results = buildSeedResults();
+
+    expect(results).toHaveLength(6);
+    expect(results.map((result) => readGlobalSearchEntityLabel(result.entityType))).toEqual([
+      "Task",
+      "Task",
+      "Task",
+      "Project",
+      "Project",
+      "Initiative",
+    ]);
+  });
+
+  /**
+   * Verifies that task metadata like details, tags, project names, and initiative names all
+   * contribute to the normalized search string for the MVP matcher.
+   */
+  it("matches task results by details, tags, project names, and initiative names", () => {
+    const results = buildSeedResults();
+
+    expect(filterGlobalSearchResults(results, "editable").map((result) => result.id)).toEqual([
+      "task-2",
+    ]);
+    expect(filterGlobalSearchResults(results, "high-priority").map((result) => result.id)).toEqual([
+      "task-2",
+    ]);
+    expect(filterGlobalSearchResults(results, "relay mvp").map((result) => result.id)).toEqual([
+      "task-1",
+      "task-2",
+      "project-1",
+    ]);
+    expect(filterGlobalSearchResults(results, "product launch").map((result) => result.id)).toEqual([
+      "task-1",
+      "task-2",
+      "project-1",
+      "initiative-1",
+    ]);
+  });
+
+  /**
+   * Confirms initiative descriptions remain searchable even when the initiative name does not
+   * contain the query string.
+   */
+  it("matches initiative results by description text", () => {
+    const results = buildSeedResults();
+
+    expect(filterGlobalSearchResults(results, "marketing").map((result) => result.id)).toEqual([
+      "initiative-1",
+    ]);
+  });
+
+  /**
+   * Keeps the task context label understandable when a task belongs to both a project and
+   * an initiative.
+   */
+  it("attaches parent context labels to task results", () => {
+    const result = buildSeedResults().find((candidate) => candidate.id === "task-1");
+
+    expect(result?.contextLabel).toBe(
+      "Project: Relay MVP · Initiative: Q2 Product Launch",
+    );
+  });
+
+  /**
+   * Ensures task selections clear or set filters so the chosen task can still be seen.
+   */
+  it("maps task selections back into the tasks view", () => {
+    const results = buildSeedResults();
+    const taskResult = results.find((candidate) => candidate.id === "task-1");
+
+    expect(taskResult).toBeDefined();
+    expect(resolveGlobalSearchSelection(taskResult!, workspaceSeed)).toEqual({
+      activeMenu: "tasks",
+      filterProjectId: "project-1",
+      filterInitiativeId: null,
+      selectedTaskId: "task-1",
+    });
+  });
+
+  /**
+   * Reuses the project-to-task workflow by selecting the first matching task when one exists.
+   */
+  it("maps project selections into the filtered tasks view", () => {
+    const results = buildSeedResults();
+    const projectResult = results.find((candidate) => candidate.id === "project-1");
+
+    expect(projectResult).toBeDefined();
+    expect(resolveGlobalSearchSelection(projectResult!, workspaceSeed)).toEqual({
+      activeMenu: "tasks",
+      filterProjectId: "project-1",
+      filterInitiativeId: null,
+      selectedTaskId: "task-1",
+    });
+  });
+
+  /**
+   * Leaves the task drill-down closed when a searched project has no linked tasks yet.
+   */
+  it("keeps project selections on the overview when the project has no tasks", () => {
+    const results = buildSeedResults();
+    const projectResult = results.find((candidate) => candidate.id === "project-2");
+
+    expect(projectResult).toBeDefined();
+    expect(resolveGlobalSearchSelection(projectResult!, workspaceSeed)).toEqual({
+      activeMenu: "tasks",
+      filterProjectId: "project-2",
+      filterInitiativeId: null,
+      selectedTaskId: null,
+    });
+  });
+
+  /**
+   * Preserves the initiative filter flow already used by the initiatives list.
+   */
+  it("maps initiative selections into the filtered projects view", () => {
+    const results = buildSeedResults();
+    const initiativeResult = results.find((candidate) => candidate.id === "initiative-1");
+
+    expect(initiativeResult).toBeDefined();
+    expect(resolveGlobalSearchSelection(initiativeResult!, workspaceSeed)).toEqual({
+      activeMenu: "projects",
+      filterProjectId: null,
+      filterInitiativeId: "initiative-1",
+      selectedTaskId: null,
+    });
+  });
+});
+
+describe("global search keyboard helpers", () => {
+  /**
+   * Wraps keyboard navigation to the top when the user advances past the final result.
+   */
+  it("cycles forward through the result list", () => {
+    expect(cycleGlobalSearchIndex(0, "next", 3)).toBe(1);
+    expect(cycleGlobalSearchIndex(2, "next", 3)).toBe(0);
+  });
+
+  /**
+   * Wraps keyboard navigation to the bottom when the user moves above the first result.
+   */
+  it("cycles backward through the result list", () => {
+    expect(cycleGlobalSearchIndex(1, "previous", 3)).toBe(0);
+    expect(cycleGlobalSearchIndex(0, "previous", 3)).toBe(2);
+  });
+
+  /**
+   * Keeps empty result sets from producing invalid active selections.
+   */
+  it("returns a sentinel index when there are no results", () => {
+    expect(cycleGlobalSearchIndex(0, "next", 0)).toBe(-1);
+  });
+});

--- a/src/features/workspace/global-search.ts
+++ b/src/features/workspace/global-search.ts
@@ -1,0 +1,229 @@
+import { type WorkspaceMenu } from "./workspace-navigation";
+import { type WorkspaceSnapshot } from "./types";
+
+export type GlobalSearchEntityType = "task" | "project" | "initiative";
+
+export interface GlobalSearchResult {
+  id: string;
+  entityType: GlobalSearchEntityType;
+  title: string;
+  description: string;
+  contextLabel: string;
+  projectId: string | null;
+  initiativeId: string | null;
+  normalizedSearchText: string;
+}
+
+export interface SearchNavigationIntent {
+  activeMenu: WorkspaceMenu;
+  filterProjectId: string | null;
+  filterInitiativeId: string | null;
+  selectedTaskId: string | null;
+}
+
+/**
+ * Flattens initiatives, projects, and tasks into one searchable list with enough parent context
+ * to keep duplicate names understandable in the dialog.
+ */
+export function buildGlobalSearchResults(
+  workspace: WorkspaceSnapshot,
+): GlobalSearchResult[] {
+  const initiativeNameById = new Map(
+    workspace.initiatives.map((initiative) => [initiative.id, initiative.name]),
+  );
+  const projectById = new Map(
+    workspace.projects.map((project) => [project.id, project]),
+  );
+
+  const taskResults = workspace.tasks.map((task) => {
+    const project = task.projectId ? projectById.get(task.projectId) : undefined;
+    const projectName = project?.name ?? null;
+    const initiativeName = project?.initiativeId
+      ? initiativeNameById.get(project.initiativeId) ?? null
+      : null;
+
+    return {
+      id: task.id,
+      entityType: "task" as const,
+      title: task.title,
+      description: task.details,
+      contextLabel: readTaskContextLabel(projectName, initiativeName),
+      projectId: readOptionalValue(task.projectId),
+      initiativeId: readOptionalValue(project?.initiativeId),
+      normalizedSearchText: normalizeSearchText([
+        task.title,
+        task.details,
+        ...task.tags,
+        projectName,
+        initiativeName,
+      ]),
+    };
+  });
+
+  const projectResults = workspace.projects.map((project) => {
+    const initiativeName = project.initiativeId
+      ? initiativeNameById.get(project.initiativeId) ?? null
+      : null;
+
+    return {
+      id: project.id,
+      entityType: "project" as const,
+      title: project.name,
+      description: "",
+      contextLabel: initiativeName
+        ? `Initiative: ${initiativeName}`
+        : "No initiative",
+      projectId: project.id,
+      initiativeId: readOptionalValue(project.initiativeId),
+      normalizedSearchText: normalizeSearchText([
+        project.name,
+        initiativeName,
+      ]),
+    };
+  });
+
+  const initiativeResults = workspace.initiatives.map((initiative) => ({
+    id: initiative.id,
+    entityType: "initiative" as const,
+    title: initiative.name,
+    description: initiative.description,
+    contextLabel: initiative.description || "No description",
+    projectId: null,
+    initiativeId: initiative.id,
+    normalizedSearchText: normalizeSearchText([
+      initiative.name,
+      initiative.description,
+    ]),
+  }));
+
+  return [...taskResults, ...projectResults, ...initiativeResults];
+}
+
+/**
+ * Applies simple normalized substring matching for the dialog's MVP search behavior.
+ */
+export function filterGlobalSearchResults(
+  results: GlobalSearchResult[],
+  query: string,
+): GlobalSearchResult[] {
+  const normalizedQuery = normalizeSearchText([query]);
+
+  if (!normalizedQuery) {
+    return results;
+  }
+
+  return results.filter((result) =>
+    result.normalizedSearchText.includes(normalizedQuery),
+  );
+}
+
+/**
+ * Cycles the highlighted result index so keyboard navigation wraps cleanly through the list.
+ */
+export function cycleGlobalSearchIndex(
+  currentIndex: number,
+  direction: "next" | "previous",
+  resultCount: number,
+): number {
+  if (resultCount <= 0) {
+    return -1;
+  }
+
+  if (currentIndex < 0 || currentIndex >= resultCount) {
+    return direction === "next" ? 0 : resultCount - 1;
+  }
+
+  if (direction === "next") {
+    return currentIndex === resultCount - 1 ? 0 : currentIndex + 1;
+  }
+
+  return currentIndex === 0 ? resultCount - 1 : currentIndex - 1;
+}
+
+/**
+ * Converts a selected search result into the app-shell navigation state that should be applied.
+ */
+export function resolveGlobalSearchSelection(
+  result: GlobalSearchResult,
+  workspace: WorkspaceSnapshot,
+): SearchNavigationIntent {
+  switch (result.entityType) {
+    case "task":
+      return {
+        activeMenu: "tasks",
+        filterProjectId: result.projectId,
+        filterInitiativeId: null,
+        selectedTaskId: result.id,
+      };
+    case "project":
+      return {
+        activeMenu: "tasks",
+        filterProjectId: result.id,
+        filterInitiativeId: null,
+        selectedTaskId:
+          workspace.tasks.find((task) => task.projectId === result.id)?.id ?? null,
+      };
+    case "initiative":
+      return {
+        activeMenu: "projects",
+        filterProjectId: null,
+        filterInitiativeId: result.id,
+        selectedTaskId: null,
+      };
+  }
+}
+
+/**
+ * Converts an internal entity type into the short label shown in each search row.
+ */
+export function readGlobalSearchEntityLabel(
+  entityType: GlobalSearchEntityType,
+): string {
+  switch (entityType) {
+    case "task":
+      return "Task";
+    case "project":
+      return "Project";
+    case "initiative":
+      return "Initiative";
+  }
+}
+
+/**
+ * Produces a stable human-readable task context string from the task's parent entities.
+ */
+function readTaskContextLabel(
+  projectName: string | null,
+  initiativeName: string | null,
+): string {
+  if (projectName && initiativeName) {
+    return `Project: ${projectName} · Initiative: ${initiativeName}`;
+  }
+
+  if (projectName) {
+    return `Project: ${projectName}`;
+  }
+
+  return "No project";
+}
+
+/**
+ * Normalizes search text into a single lowercase whitespace-collapsed string.
+ */
+function normalizeSearchText(values: Array<string | null | undefined>): string {
+  return values
+    .map((value) => value?.trim().toLowerCase() ?? "")
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Treats empty strings as missing values so app state stays consistent across selection flows.
+ */
+function readOptionalValue(value: string | null | undefined): string | null {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue ? trimmedValue : null;
+}

--- a/src/features/workspace/task-management-view.tsx
+++ b/src/features/workspace/task-management-view.tsx
@@ -38,6 +38,7 @@ interface TaskManagementViewProps {
   activeProviderModel: string;
   isActiveProviderReady: boolean;
   taskGroupingMode: TaskGroupingMode;
+  onClearProjectFilter: () => void;
   onSetNewTaskTitle: (value: string) => void;
   onSetNewTaskDetails: (value: string) => void;
   onSetNewTaskProject: (value: string) => void;
@@ -54,7 +55,6 @@ interface TaskManagementViewProps {
   onSetEditDetails: (value: string) => void;
   onSetEditProject: (value: string) => void;
   onSetEditTags: (value: string) => void;
-  onClearProjectFilter: () => void;
   onThreadDraftChange: (taskId: string, message: string) => void;
   onSendThreadMessage: (taskId: string) => void;
   onToggleGroupingMode: () => void;
@@ -83,6 +83,7 @@ export function TaskManagementView({
   activeProviderModel,
   isActiveProviderReady,
   taskGroupingMode,
+  onClearProjectFilter,
   onSetNewTaskTitle,
   onSetNewTaskDetails,
   onSetNewTaskProject,
@@ -99,7 +100,6 @@ export function TaskManagementView({
   onSetEditDetails,
   onSetEditProject,
   onSetEditTags,
-  onClearProjectFilter,
   onThreadDraftChange,
   onSendThreadMessage,
   onToggleGroupingMode,

--- a/src/features/workspace/workspace-app.tsx
+++ b/src/features/workspace/workspace-app.tsx
@@ -7,6 +7,7 @@ import {
   buildDeleteTaskConfirmationMessage,
   buildDeleteThreadMessageConfirmationMessage,
 } from "@/features/workspace/delete-confirmation";
+import { GlobalSearchDialog } from "@/features/workspace/global-search-dialog";
 import {
   addInitiative,
   deleteInitiative,
@@ -67,6 +68,12 @@ import {
   workspaceThemeSelectionStorageKey,
   type WorkspaceThemeSelection,
 } from "@/features/workspace/workspace-theme";
+import {
+  buildGlobalSearchResults,
+  filterGlobalSearchResults,
+  resolveGlobalSearchSelection,
+  type GlobalSearchResult,
+} from "@/features/workspace/global-search";
 
 /**
  * Hosts the app shell, view switching, and task/configuration state wiring.
@@ -86,6 +93,9 @@ export function WorkspaceApp() {
   const [themeSelection, setThemeSelection] = useState<WorkspaceThemeSelection>(
     defaultWorkspaceThemeSelection,
   );
+  const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false);
+  const [globalSearchQuery, setGlobalSearchQuery] = useState("");
+  const [activeGlobalSearchIndex, setActiveGlobalSearchIndex] = useState(0);
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const [newTaskDetails, setNewTaskDetails] = useState("");
   const [newTaskProject, setNewTaskProject] = useState("");
@@ -116,6 +126,10 @@ export function WorkspaceApp() {
         ownerId: selectedTask.id,
       })
     : createEmptyThreadDraft();
+  const globalSearchResults = filterGlobalSearchResults(
+    buildGlobalSearchResults(workspace),
+    globalSearchQuery,
+  );
 
   /**
    * Hydrates saved workspace data after mount so task edits survive a browser refresh.
@@ -245,6 +259,56 @@ export function WorkspaceApp() {
   }, [themeSelection, hasLoadedThemeSelection]);
 
   /**
+   * Opens the global search dialog from anywhere in the workspace with the platform-standard
+   * quick-search shortcut.
+   */
+  useEffect(() => {
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+
+        if (isGlobalSearchOpen) {
+          return;
+        }
+
+        setGlobalSearchQuery("");
+        setActiveGlobalSearchIndex(0);
+        setIsGlobalSearchOpen(true);
+      }
+    }
+
+    window.addEventListener("keydown", handleWindowKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleWindowKeyDown);
+    };
+  }, [isGlobalSearchOpen]);
+
+  /**
+   * Resets the highlighted search row whenever the query changes so Enter always targets the
+   * first visible match by default.
+   */
+  useEffect(() => {
+    setActiveGlobalSearchIndex(0);
+  }, [globalSearchQuery, isGlobalSearchOpen]);
+
+  /**
+   * Clamps the highlighted search row if the result list shrinks after workspace or query updates.
+   */
+  useEffect(() => {
+    if (globalSearchResults.length === 0) {
+      setActiveGlobalSearchIndex(0);
+      return;
+    }
+
+    setActiveGlobalSearchIndex((currentIndex) =>
+      currentIndex >= globalSearchResults.length
+        ? globalSearchResults.length - 1
+        : currentIndex,
+    );
+  }, [globalSearchResults.length]);
+
+  /**
    * Opens or closes the slim top menu without changing the active workspace view.
    */
   function handleToggleTopMenu() {
@@ -292,6 +356,8 @@ export function WorkspaceApp() {
   }
 
   function handleSelectInitiative(initiativeId: string) {
+    clearTaskFocus();
+    setFilterProjectId(null);
     setFilterInitiativeId(initiativeId);
     setActiveMenu("projects");
   }
@@ -374,6 +440,14 @@ export function WorkspaceApp() {
     setNewTaskDetails("");
     setNewTaskProject("");
     setNewTaskTags("");
+  }
+
+  /**
+   * Clears task-detail-specific UI state without mutating the underlying task data.
+   */
+  function clearTaskFocus() {
+    handleCancelEdit();
+    setSelectedTaskId(null);
   }
 
   /**
@@ -710,6 +784,35 @@ export function WorkspaceApp() {
     }
   }
 
+  /**
+   * Closes and resets the global search dialog so each open starts from a clean query.
+   */
+  function handleCloseGlobalSearch() {
+    setIsGlobalSearchOpen(false);
+    setGlobalSearchQuery("");
+    setActiveGlobalSearchIndex(0);
+  }
+
+  /**
+   * Applies one selected search result to the app shell by reusing the existing menu and filter
+   * state wherever possible.
+   */
+  function handleSelectGlobalSearchResult(result: GlobalSearchResult) {
+    const selection = resolveGlobalSearchSelection(result, workspace);
+
+    setFilterProjectId(selection.filterProjectId);
+    setFilterInitiativeId(selection.filterInitiativeId);
+    setActiveMenu(selection.activeMenu);
+
+    if (selection.selectedTaskId) {
+      handleOpenTask(selection.selectedTaskId);
+    } else {
+      clearTaskFocus();
+    }
+
+    handleCloseGlobalSearch();
+  }
+
   return (
     <main
       className="workspace-theme-stage min-h-screen px-4 py-6 text-[color:var(--foreground)]"
@@ -717,6 +820,16 @@ export function WorkspaceApp() {
       data-theme-pair={themeSelection.themeId}
       style={buildWorkspaceThemeStyle(themeSelection)}
     >
+      <GlobalSearchDialog
+        activeIndex={activeGlobalSearchIndex}
+        isOpen={isGlobalSearchOpen}
+        onActiveIndexChange={setActiveGlobalSearchIndex}
+        onClose={handleCloseGlobalSearch}
+        onQueryChange={setGlobalSearchQuery}
+        onSelectResult={handleSelectGlobalSearchResult}
+        query={globalSearchQuery}
+        results={globalSearchResults}
+      />
       <div className="mx-auto max-w-4xl">
         <WorkspaceTopMenu
           activeMenu={activeMenu}


### PR DESCRIPTION
## Summary
- add a local global search index and dialog for tasks, projects, and initiatives
- wire Cmd+K / Ctrl+K keyboard handling, arrow-key navigation, and Enter/Escape behavior into the workspace shell
- reuse project and initiative navigation flows, including task project filtering so selected results land in a visible destination

## Testing
- npm test
- npm run lint
- npm run build

Closes #8