### PR TITLE
Adopt stock shadcn UI across the workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Relay is currently a minimal web starter for task management with two primary id
 
 - A compact task overview list
 - A selected-task inline editor that expands inside the current list
-- A thin top-menu shell that separates Tasks from Configuration
+- A thin workspace shell with sidebar navigation, top-level menu switching, and command search
 
 The current goal is to keep the product as small as possible before layering on more capabilities.
 
@@ -31,13 +31,13 @@ The current goal is to keep the product as small as possible before layering on 
 - `src/features/workspace/initiatives/*`: initiative operations
 - `src/features/workspace/providers/*`: provider request and configuration helpers
 - `src/features/workspace/threads/*`: thread rendering, ids, and context helpers
-- `src/features/workspace/search/*`: command search helpers and dialog
+- `src/features/workspace/search/*`: command search helpers and the command-palette dialog
 - `src/features/workspace/storage/*`: workspace local storage helpers
 - `src/features/workspace/theme/*`: theme registry and selector
-- `src/features/workspace/navigation/*`: menu metadata and top-menu UI
+- `src/features/workspace/navigation/*`: sidebar navigation, top-menu UI, and menu metadata
 - `config/next/*`: Next dev-server config helpers
 - `src/app/api/agent-call/route.ts`: live provider-backed agent endpoint
-- `src/components/ui/*`: small shared UI primitives
+- `src/components/ui/*`: small shared UI primitives, including sidebar and command shell building blocks
 
 ## Design Guidelines
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This app lives at the repository root (`ai-task-manager/`).
 - One shared inline task editor that expands beneath the selected row across inbox, task lists, and project detail
 - A thin desktop top menu that opens from the current-view label
 - Theme options in Configuration with 6 paired day/night UI directions, including Relay Original
+- Configuration sections built on shadcn-style accordion and card surfaces instead of custom disclosure markup
 - Add a task
 - Edit a task inline without leaving the list
 - Delete a task
@@ -24,7 +25,7 @@ This app lives at the repository root (`ai-task-manager/`).
 - Next.js 16
 - TypeScript
 - Tailwind CSS v4
-- shadcn-style primitives with shared design tokens and Radix-backed Select, Dialog, DropdownMenu, Tooltip, Label, and Separator behavior
+- shadcn-style primitives with shared design tokens and Radix-backed Select, Dialog, DropdownMenu, Tooltip, Label, Separator, and Accordion behavior
 - Vitest
 
 ## Commands
@@ -80,7 +81,7 @@ The app is the primary project in this repository.
 - `src/features/workspace/theme/*`: theme registry and selector
 - `src/features/workspace/navigation/*`: top-menu UI and menu metadata
 - `config/next/*`: Next dev-server config helpers and tests
-- `src/components/ui/*`: reusable shadcn-style UI primitives, with Radix used where accessibility or composition needs it across Select, Dialog, DropdownMenu, Tooltip, Label, and Separator
+- `src/components/ui/*`: reusable shadcn-style UI primitives, with Radix used where accessibility or composition needs it across Select, Dialog, DropdownMenu, Tooltip, Label, Separator, and Accordion
 
 ## Product Assumptions
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This app lives at the repository root (`ai-task-manager/`).
 - Next.js 16
 - TypeScript
 - Tailwind CSS v4
-- shadcn-style primitives with shared design tokens and Radix-backed Select, Dialog, DropdownMenu, Tooltip, Label, Separator, and Accordion behavior
+- shadcn-style primitives with shared design tokens, plus sidebar, command-palette, and configuration-surface patterns built on Select, Dialog, DropdownMenu, Tooltip, Label, Separator, Accordion, and Card components
 - Vitest
 
 ## Commands
@@ -76,12 +76,12 @@ The app is the primary project in this repository.
 - `src/features/workspace/initiatives/*`: initiative operations
 - `src/features/workspace/providers/*`: provider config and API helpers
 - `src/features/workspace/threads/*`: thread UI plus owner/context helpers
-- `src/features/workspace/search/*`: global search helpers and dialog
+- `src/features/workspace/search/*`: global search helpers and the command-palette dialog
 - `src/features/workspace/storage/*`: workspace local storage helpers and normalization
 - `src/features/workspace/theme/*`: theme registry and selector
-- `src/features/workspace/navigation/*`: top-menu UI and menu metadata
+- `src/features/workspace/navigation/*`: sidebar and top-navigation shell UI plus menu metadata
 - `config/next/*`: Next dev-server config helpers and tests
-- `src/components/ui/*`: reusable shadcn-style UI primitives, with Radix used where accessibility or composition needs it across Select, Dialog, DropdownMenu, Tooltip, Label, Separator, and Accordion
+- `src/components/ui/*`: reusable shadcn-style UI primitives, including sidebar, command, accordion, card, dialog, dropdown, tooltip, and form building blocks used across the workspace shell
 
 ## Product Assumptions
 

--- a/docs/issue-30-stock-shadcn-config-plan.md
+++ b/docs/issue-30-stock-shadcn-config-plan.md
@@ -1,0 +1,11 @@
+# Issue 30 Plan
+
+Source issue: `#30`
+
+## Execution Notes
+
+- Add a small shadcn-style accordion primitive so Configuration can move off native `details` and `summary`.
+- Update the configuration view tests first so they assert accordion-driven sections and the simplified theme selector structure.
+- Simplify the workspace theme selector onto quieter card and button selection patterns while preserving the existing theme data and callback behavior.
+- Remove custom disclosure styling that becomes unnecessary after the accordion migration.
+- Verify with targeted tests, then run the broader relevant suite for regression coverage.

--- a/docs/issue-31-task-flows-plan.md
+++ b/docs/issue-31-task-flows-plan.md
@@ -1,0 +1,24 @@
+# Issue 31 Plan
+
+Source issue: `#31`
+
+## Goal
+
+Standardize task create and edit flows on the shared shadcn-style editor surface and replace the
+custom tag combobox with a stock-looking tag picker while preserving the current keyboard-driven
+workflow.
+
+## Execution Notes
+
+- Keep the dedicated issue-31 worktree and branch isolated from the main checkout.
+- Rework `TaskEditorFields` into a shared labeled form layout using the existing shadcn-style
+  `Button`, `Input`, `Textarea`, `Select`, `Separator`, and `Label` primitives.
+- Reuse that shared editor for both inbox task creation and the general task management composer so
+  task creation no longer splits between two different UI patterns.
+- Replace the custom inline tag combobox with a popover-style tag picker that still supports
+  selecting known tags, creating new tags, and removing selected tags.
+- Preserve the current keyboard contracts: Cmd/Ctrl+Enter submits, Escape closes popovers first,
+  then collapses or cancels the parent editor.
+- Update the touched static-render and helper tests to match the new shared form composition.
+- Verify the slice with targeted tests, then broader lint and test runs if the local environment
+  cooperates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -2590,6 +2591,61 @@
       }
     },
     "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "task-manager",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -2224,6 +2225,37 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -2231,6 +2263,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,8 @@
   --primary-foreground: #fafafa;
   --secondary: #f4f4f5;
   --secondary-foreground: #3f3f46;
+  --destructive: #dc2626;
+  --destructive-foreground: #fafafa;
   --popover: #ffffff;
   --popover-foreground: #18181b;
   --input: #d4d4d8;
@@ -51,6 +53,8 @@
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-muted: var(--surface-muted);
@@ -99,7 +103,6 @@ body {
     background 180ms ease,
     color 180ms ease;
 }
-
 button,
 input,
 textarea,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,63 +100,6 @@ body {
     color 180ms ease;
 }
 
-.workspace-theme-panel {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-strong) 92%, white 8%),
-      color-mix(in srgb, var(--surface) 95%, var(--background) 5%)
-    );
-  box-shadow: 0 24px 60px -36px var(--shadow-color);
-  backdrop-filter: blur(14px);
-}
-
-.configuration-disclosure-summary::-webkit-details-marker {
-  display: none;
-}
-
-.configuration-disclosure-summary::marker {
-  content: "";
-}
-
-.configuration-disclosure-summary {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 0.75rem;
-}
-
-.configuration-disclosure-copy {
-  min-width: 0;
-}
-
-.configuration-disclosure-meta {
-  min-width: 0;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding-left: 0.5rem;
-}
-
-.configuration-disclosure-status {
-  max-width: 10rem;
-  overflow: hidden;
-  color: var(--muted-strong);
-  font-size: var(--font-size-xs);
-  line-height: 1rem;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.configuration-disclosure-chevron {
-  transition: transform 180ms ease;
-}
-
-.configuration-disclosure[open] .configuration-disclosure-chevron {
-  transform: rotate(180deg);
-}
-
 button,
 input,
 textarea,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,14 +95,6 @@ body {
   color: var(--foreground);
 }
 
-.workspace-theme-stage {
-  background:
-    radial-gradient(circle at top right, var(--backdrop-spotlight), transparent 34%),
-    linear-gradient(180deg, var(--backdrop-start), var(--background) 24%, var(--backdrop-end));
-  transition:
-    background 180ms ease,
-    color 180ms ease;
-}
 button,
 input,
 textarea,

--- a/src/app/shadcn-foundation.test.ts
+++ b/src/app/shadcn-foundation.test.ts
@@ -62,9 +62,13 @@ describe("shadcn foundation", () => {
     expect(globalsCss).toContain("--font-size-base: 1rem;");
     expect(globalsCss).toContain("--font-size-xl: 1.25rem;");
     expect(globalsCss).toContain("--font-size-2xl: 1.5rem;");
+    expect(globalsCss).toContain("--destructive:");
+    expect(globalsCss).toContain("--destructive-foreground:");
     expect(globalsCss).toContain("--radius: 0.375rem;");
     expect(globalsCss).toContain("--shadow-sm:");
     expect(globalsCss).toContain("--shadow-md:");
+    expect(globalsCss).toContain("--color-destructive: var(--destructive);");
+    expect(globalsCss).toContain("--color-destructive-foreground: var(--destructive-foreground);");
     expect(globalsCss).toContain("--text-xs: var(--font-size-xs);");
     expect(globalsCss).toContain("--text-sm: var(--font-size-sm);");
     expect(globalsCss).toContain("--text-base: var(--font-size-base);");
@@ -74,5 +78,8 @@ describe("shadcn foundation", () => {
     expect(globalsCss).toContain("--radius-md: calc(var(--radius) - 2px);");
     expect(globalsCss).toContain("--radius-lg: var(--radius);");
     expect(globalsCss).toContain("--radius-xl: calc(var(--radius) + 4px);");
+    expect(globalsCss).not.toContain(".workspace-theme-stage");
+    expect(globalsCss).not.toContain(".workspace-theme-panel");
+    expect(globalsCss).not.toContain(".configuration-disclosure-summary");
   });
 });

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,75 @@
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Provides a stock shadcn-style accordion surface for collapsible sections that still respects
+ * Relay's quieter no-chrome defaults.
+ */
+const Accordion = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>
+>(function Accordion({ ...props }, ref) {
+  return <AccordionPrimitive.Root data-slot="accordion" ref={ref} {...props} />;
+});
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(function AccordionItem({ className, ...props }, ref) {
+  return (
+    <AccordionPrimitive.Item
+      className={cn("border-b last:border-b-0", className)}
+      data-slot="accordion-item"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(function AccordionTrigger({ className, children, ...props }, ref) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        className={cn(
+          "flex flex-1 items-start justify-between gap-3 py-4 text-left text-sm font-medium transition-all",
+          "outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]",
+          "[&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        data-slot="accordion-trigger"
+        ref={ref}
+        {...props}
+      >
+        {children}
+        <ChevronDown
+          aria-hidden="true"
+          className="mt-0.5 size-4 shrink-0 text-[color:var(--muted)] transition-transform duration-200"
+        />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+});
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(function AccordionContent({ className, children, ...props }, ref) {
+  return (
+    <AccordionPrimitive.Content
+      className={cn("overflow-hidden text-sm", className)}
+      data-slot="accordion-content"
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </AccordionPrimitive.Content>
+  );
+});
+
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,17 +4,14 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium uppercase tracking-[0.16em] transition-colors",
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
       variant: {
-        default:
-          "border-[color:var(--border)] bg-[color:var(--surface-muted)] text-[color:var(--muted-strong)]",
-        secondary:
-          "border-[color:var(--border-strong)] bg-[color:var(--surface-strong)] text-[color:var(--foreground)]",
-        success: "border-emerald-200 bg-emerald-50 text-emerald-800",
-        warning: "border-amber-200 bg-amber-50 text-amber-800",
-        danger: "border-rose-200 bg-rose-50 text-rose-800",
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        destructive: "border-transparent bg-destructive text-destructive-foreground",
+        outline: "text-foreground",
       },
     },
     defaultVariants: {
@@ -28,8 +25,7 @@ export interface BadgeProps
     VariantProps<typeof badgeVariants> {}
 
 /**
- * Renders compact status chips with shadcn-style variant names while keeping Relay's custom
- * success and warning states.
+ * Renders compact status chips with a near-stock shadcn variant contract.
  */
 export function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant, className }))} data-slot="badge" {...props} />;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,24 +5,23 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          "bg-[color:var(--accent)] text-[color:var(--accent-foreground)] hover:opacity-90",
+        default: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
         outline:
-          "border border-[color:var(--border)] bg-[color:var(--surface)] text-[color:var(--foreground)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-muted)]",
-        ghost:
-          "text-[color:var(--muted-strong)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]",
-        subtle:
-          "border border-[color:var(--border)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface)]",
+          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 px-3 text-xs",
-        lg: "h-10 px-5",
-        icon: "h-9 w-9",
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
       },
     },
     defaultVariants: {
@@ -32,14 +31,12 @@ const buttonVariants = cva(
   },
 );
 
-export interface ButtonProps
-  extends React.ComponentProps<"button">,
-    VariantProps<typeof buttonVariants> {
+export interface ButtonProps extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
 /**
- * Provides a shadcn-style button primitive while preserving Relay's quieter no-chrome variants.
+ * Provides a near-stock shadcn button primitive while preserving the local import path.
  */
 export function Button({
   asChild = false,

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -13,7 +13,7 @@ const Card = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(funct
   return (
     <div
       className={cn(
-        "rounded-xl border border-[color:var(--border)] bg-[color:var(--card)] text-[color:var(--card-foreground)] shadow-none",
+        "rounded-xl border border-[color:var(--border)] bg-[color:var(--card)] text-[color:var(--card-foreground)] shadow-sm",
         className,
       )}
       data-slot="card"
@@ -23,16 +23,13 @@ const Card = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(funct
   );
 });
 
-/**
- * Keeps card headers aligned with the shadcn registry structure so sections read consistently.
- */
 const CardHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardHeader(
   { className, ...props },
   ref,
 ) {
   return (
     <div
-      className={cn("flex flex-col gap-1.5 px-4 py-4", className)}
+      className={cn("flex flex-col gap-1.5 p-6", className)}
       data-slot="card-header"
       ref={ref}
       {...props}
@@ -40,16 +37,13 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>
   );
 });
 
-/**
- * Renders the primary title for a card section.
- */
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p">>(function CardTitle(
   { className, ...props },
   ref,
 ) {
   return (
-    <p
-      className={cn("text-sm font-semibold text-[color:var(--foreground)]", className)}
+      <p
+      className={cn("font-semibold leading-none tracking-tight text-[color:var(--foreground)]", className)}
       data-slot="card-title"
       ref={ref}
       {...props}
@@ -57,14 +51,11 @@ const CardTitle = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p
   );
 });
 
-/**
- * Renders supporting helper copy beneath a card title.
- */
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p">>(
   function CardDescription({ className, ...props }, ref) {
     return (
       <p
-        className={cn("text-sm leading-6 text-[color:var(--muted)]", className)}
+        className={cn("text-sm text-[color:var(--muted)]", className)}
         data-slot="card-description"
         ref={ref}
         {...props}
@@ -73,16 +64,13 @@ const CardDescription = React.forwardRef<HTMLParagraphElement, React.ComponentPr
   },
 );
 
-/**
- * Holds the main body content for a card.
- */
 const CardContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardContent(
   { className, ...props },
   ref,
 ) {
   return (
     <div
-      className={cn("px-4 pb-4", className)}
+      className={cn("p-6 pt-0", className)}
       data-slot="card-content"
       ref={ref}
       {...props}
@@ -90,16 +78,13 @@ const CardContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">
   );
 });
 
-/**
- * Keeps footer actions aligned at the bottom of a card.
- */
 const CardFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardFooter(
   { className, ...props },
   ref,
 ) {
   return (
     <div
-      className={cn("flex items-center px-4 pb-4", className)}
+      className={cn("flex items-center p-6 pt-0", className)}
       data-slot="card-footer"
       ref={ref}
       {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Provides a stock shadcn-style card surface with quieter defaults so workspace views can reuse
+ * the same structure without reaching for custom one-off wrappers.
+ */
+const Card = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function Card(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-[color:var(--border)] bg-[color:var(--card)] text-[color:var(--card-foreground)] shadow-none",
+        className,
+      )}
+      data-slot="card"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+/**
+ * Keeps card headers aligned with the shadcn registry structure so sections read consistently.
+ */
+const CardHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardHeader(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5 px-4 py-4", className)}
+      data-slot="card-header"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+/**
+ * Renders the primary title for a card section.
+ */
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p">>(function CardTitle(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <p
+      className={cn("text-sm font-semibold text-[color:var(--foreground)]", className)}
+      data-slot="card-title"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+/**
+ * Renders supporting helper copy beneath a card title.
+ */
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p">>(
+  function CardDescription({ className, ...props }, ref) {
+    return (
+      <p
+        className={cn("text-sm leading-6 text-[color:var(--muted)]", className)}
+        data-slot="card-description"
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+
+/**
+ * Holds the main body content for a card.
+ */
+const CardContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardContent(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <div
+      className={cn("px-4 pb-4", className)}
+      data-slot="card-content"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+/**
+ * Keeps footer actions aligned at the bottom of a card.
+ */
+const CardFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(function CardFooter(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <div
+      className={cn("flex items-center px-4 pb-4", className)}
+      data-slot="card-footer"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface CollapsibleContextValue {
+  open: boolean;
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+interface CollapsibleProps extends React.ComponentProps<"div"> {
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+}
+
+/**
+ * Provides a lightweight controlled/uncontrolled collapsible wrapper for the workspace shell.
+ */
+export function Collapsible({
+  children,
+  className,
+  defaultOpen = false,
+  open = defaultOpen,
+  ...props
+}: CollapsibleProps) {
+  return (
+    <CollapsibleContext.Provider value={{ open }}>
+      <div
+        className={cn(className)}
+        data-slot="collapsible"
+        data-state={open ? "open" : "closed"}
+        {...props}
+      >
+        {children}
+      </div>
+    </CollapsibleContext.Provider>
+  );
+}
+
+interface CollapsibleContentProps extends React.ComponentProps<"div"> {
+  forceMount?: boolean;
+}
+
+/**
+ * Only renders open content unless `forceMount` is requested for layout reasons.
+ */
+export function CollapsibleContent({
+  children,
+  className,
+  forceMount = false,
+  ...props
+}: CollapsibleContentProps) {
+  const context = React.useContext(CollapsibleContext);
+  const open = context?.open ?? true;
+
+  if (!open && !forceMount) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(className)}
+      data-slot="collapsible-content"
+      data-state={open ? "open" : "closed"}
+      hidden={!open}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,171 @@
+import { Search } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Command = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function Command({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-xl bg-[color:var(--surface)] text-[color:var(--foreground)]",
+        className,
+      )}
+      data-slot="command"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+interface CommandInputProps extends React.ComponentPropsWithoutRef<"input"> {
+  wrapperClassName?: string;
+}
+
+const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
+  function CommandInput({ className, wrapperClassName, ...props }, ref) {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-3 border-b border-[color:var(--border)] px-3",
+          wrapperClassName,
+        )}
+        data-slot="command-input-wrapper"
+      >
+        <Search
+          aria-hidden="true"
+          className="size-4 shrink-0 text-[color:var(--muted)]"
+        />
+        <input
+          className={cn(
+            "flex h-12 w-full bg-transparent text-sm outline-none placeholder:text-[color:var(--muted)]",
+            className,
+          )}
+          data-slot="command-input"
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+
+const CommandList = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function CommandList({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn("max-h-[24rem] overflow-y-auto p-2", className)}
+      data-slot="command-list"
+      ref={ref}
+      role="listbox"
+      {...props}
+    />
+  );
+});
+
+const CommandEmpty = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
+>(function CommandEmpty({ className, ...props }, ref) {
+  return (
+    <p
+      className={cn("rounded-md px-3 py-6 text-sm text-[color:var(--muted)]", className)}
+      data-slot="command-empty"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+interface CommandGroupProps extends React.ComponentPropsWithoutRef<"div"> {
+  heading?: string;
+}
+
+const CommandGroup = React.forwardRef<HTMLDivElement, CommandGroupProps>(
+  function CommandGroup({ children, className, heading, ...props }, ref) {
+    return (
+      <div className={cn("space-y-1", className)} data-slot="command-group" ref={ref} {...props}>
+        {heading ? (
+          <p className="px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            {heading}
+          </p>
+        ) : null}
+        {children}
+      </div>
+    );
+  },
+);
+
+interface CommandItemProps extends React.ComponentPropsWithoutRef<"button"> {
+  selected?: boolean;
+}
+
+const CommandItem = React.forwardRef<HTMLButtonElement, CommandItemProps>(
+  function CommandItem(
+    { className, selected = false, type = "button", ...props },
+    ref,
+  ) {
+    return (
+      <button
+        aria-selected={selected}
+        className={cn(
+          "w-full rounded-lg border px-3 py-3 text-left transition outline-none",
+          "focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
+          selected
+            ? "border-[color:var(--foreground)] bg-[color:var(--surface-strong)]"
+            : "border-transparent hover:border-[color:var(--border)] hover:bg-[color:var(--surface-strong)]",
+          className,
+        )}
+        data-selected={selected ? "true" : "false"}
+        data-slot="command-item"
+        ref={ref}
+        role="option"
+        type={type}
+        {...props}
+      />
+    );
+  },
+);
+
+const CommandSeparator = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function CommandSeparator({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn("h-px bg-[color:var(--border)]", className)}
+      data-slot="command-separator"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const CommandShortcut = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(function CommandShortcut({ className, ...props }, ref) {
+  return (
+    <span
+      className={cn("text-xs tracking-[0.14em] text-[color:var(--muted)]", className)}
+      data-slot="command-shortcut"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+export {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -25,7 +25,7 @@ const DialogOverlay = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        "fixed inset-0 z-50 bg-black/35",
+        "fixed inset-0 z-50 bg-black/50",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,
@@ -47,7 +47,7 @@ const DialogContent = React.forwardRef<
       <DialogOverlay />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-12 z-50 grid w-[min(calc(100%-2rem),42rem)] -translate-x-1/2 gap-4 border border-[color:var(--border)] bg-[color:var(--surface)] p-4 shadow-md outline-none sm:rounded-xl",
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg outline-none duration-200 sm:max-w-lg sm:rounded-lg",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -71,7 +71,7 @@ function DialogHeader({
 }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex flex-col gap-1.5 text-left", className)}
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
       data-slot="dialog-header"
       {...props}
     />
@@ -97,7 +97,7 @@ const DialogTitle = React.forwardRef<
 >(function DialogTitle({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Title
-      className={cn("text-sm font-medium text-[color:var(--foreground)]", className)}
+      className={cn("text-lg leading-none font-semibold", className)}
       data-slot="dialog-title"
       ref={ref}
       {...props}
@@ -111,7 +111,7 @@ const DialogDescription = React.forwardRef<
 >(function DialogDescription({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Description
-      className={cn("text-sm leading-6 text-[color:var(--muted)]", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       data-slot="dialog-description"
       ref={ref}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -42,8 +42,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   return (
     <DropdownMenuPrimitive.SubTrigger
       className={cn(
-        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
-        "focus:bg-[color:var(--surface-muted)] data-[state=open]:bg-[color:var(--surface-muted)]",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
         inset && "pl-8",
         className,
       )}
@@ -64,7 +63,7 @@ const DropdownMenuSubContent = React.forwardRef<
   return (
     <DropdownMenuPrimitive.SubContent
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[color:var(--border)] bg-[color:var(--popover)] p-1 text-[color:var(--popover-foreground)] shadow-md",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -87,7 +86,7 @@ const DropdownMenuContent = React.forwardRef<
     <DropdownMenuPortal>
       <DropdownMenuPrimitive.Content
         className={cn(
-          "z-50 min-w-[10rem] overflow-hidden rounded-md border border-[color:var(--border)] bg-[color:var(--popover)] p-1 text-[color:var(--popover-foreground)] shadow-md",
+          "z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -113,8 +112,7 @@ const DropdownMenuItem = React.forwardRef<
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
-        "focus:bg-[color:var(--surface-muted)] focus:text-[color:var(--foreground)]",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
         "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         inset && "pl-8",
         className,
@@ -134,8 +132,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     <DropdownMenuPrimitive.CheckboxItem
       checked={checked}
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
-        "focus:bg-[color:var(--surface-muted)] focus:text-[color:var(--foreground)]",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
         "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
@@ -160,8 +157,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   return (
     <DropdownMenuPrimitive.RadioItem
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
-        "focus:bg-[color:var(--surface-muted)] focus:text-[color:var(--foreground)]",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
         "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
@@ -188,7 +184,7 @@ const DropdownMenuLabel = React.forwardRef<
   return (
     <DropdownMenuPrimitive.Label
       className={cn(
-        "px-2 py-1.5 text-xs font-medium uppercase tracking-[0.12em] text-[color:var(--muted)]",
+        "px-2 py-1.5 text-sm font-semibold",
         inset && "pl-8",
         className,
       )}
@@ -205,7 +201,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(function DropdownMenuSeparator({ className, ...props }, ref) {
   return (
     <DropdownMenuPrimitive.Separator
-      className={cn("-mx-1 my-1 h-px bg-[color:var(--border)]", className)}
+      className={cn("-mx-1 my-1 h-px bg-muted", className)}
       data-slot="dropdown-menu-separator"
       ref={ref}
       {...props}
@@ -219,7 +215,7 @@ function DropdownMenuShortcut({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-[0.14em] text-[color:var(--muted)]", className)}
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
       data-slot="dropdown-menu-shortcut"
       {...props}
     />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -3,24 +3,23 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * Provides a shadcn-style text input with Relay's restrained border and focus treatment.
+ * Provides a near-stock shadcn text input while keeping the existing shared import path.
  */
-export const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  function Input({ className, type = "text", ...props }, ref) {
-    return (
-      <input
-        className={cn(
-          "flex h-10 w-full min-w-0 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
-          "file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[color:var(--muted)]",
-          "focus-visible:border-[color:var(--border-strong)] focus-visible:bg-[color:var(--surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        data-slot="input"
-        ref={ref}
-        type={type}
-        {...props}
-      />
-    );
-  },
-);
+export function Input({ className, type = "text", ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      data-slot="input"
+      className={cn(
+        "flex h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs outline-none transition-[color,box-shadow]",
+        "file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "aria-invalid:border-destructive",
+        className,
+      )}
+      type={type}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -5,19 +5,22 @@ import { cn } from "@/lib/utils";
 /**
  * Provides a shadcn-style text input with Relay's restrained border and focus treatment.
  */
-export function Input({ className, type = "text", ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      data-slot="input"
-      className={cn(
-        "flex h-10 w-full min-w-0 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
-        "file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[color:var(--muted)]",
-        "focus-visible:border-[color:var(--border-strong)] focus-visible:bg-[color:var(--surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
-      type={type}
-      {...props}
-    />
-  );
-}
+export const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  function Input({ className, type = "text", ...props }, ref) {
+    return (
+      <input
+        className={cn(
+          "flex h-10 w-full min-w-0 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
+          "file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[color:var(--muted)]",
+          "focus-visible:border-[color:var(--border-strong)] focus-visible:bg-[color:var(--surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        data-slot="input"
+        ref={ref}
+        type={type}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -10,7 +10,7 @@ const Label = React.forwardRef<
   return (
     <LabelPrimitive.Root
       className={cn(
-        "text-sm font-medium leading-none text-[color:var(--foreground)] peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        "flex items-center gap-2 text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       data-slot="label"

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,61 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>
+>(function PopoverTrigger({ className, ...props }, ref) {
+  return (
+    <PopoverPrimitive.Trigger
+      className={cn(className)}
+      data-slot="popover-trigger"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const PopoverAnchor = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Anchor>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Anchor>
+>(function PopoverAnchor({ className, ...props }, ref) {
+  return (
+    <PopoverPrimitive.Anchor
+      className={cn(className)}
+      data-slot="popover-anchor"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(function PopoverContent(
+  { align = "center", className, forceMount, sideOffset = 8, ...props },
+  ref,
+) {
+  return (
+    <PopoverPrimitive.Portal forceMount={forceMount}>
+      <PopoverPrimitive.Content
+        align={align}
+        className={cn(
+          "z-50 w-72 rounded-md border border-[color:var(--border)] bg-[color:var(--popover)] p-4 text-[color:var(--popover-foreground)] shadow-md outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          className,
+        )}
+        data-slot="popover-content"
+        ref={ref}
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+});
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/src/components/ui/primitives.test.tsx
+++ b/src/components/ui/primitives.test.tsx
@@ -1,8 +1,21 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "./accordion";
 import { Badge } from "./badge";
 import { Button } from "./button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./card";
 import {
   Dialog,
   DialogContent,
@@ -129,5 +142,38 @@ describe("workspace ui primitives", () => {
     expect(markup).toContain('data-slot="popover-trigger"');
     expect(markup).toContain('data-slot="label"');
     expect(markup).toContain('data-slot="separator"');
+  });
+
+  /**
+   * Confirms the configuration-specific stock shadcn surfaces stay available in the shared layer
+   * instead of being rebuilt ad hoc inside workspace views.
+   */
+  it("renders accordion and card with named slots", () => {
+    const markup = renderToStaticMarkup(
+      <Accordion collapsible defaultValue="theme" type="single">
+        <AccordionItem value="theme">
+          <AccordionTrigger>Workspace theme</AccordionTrigger>
+          <AccordionContent forceMount>
+            <Card>
+              <CardHeader>
+                <CardTitle>Relay Original</CardTitle>
+                <CardDescription>Neutral starter palette.</CardDescription>
+              </CardHeader>
+              <CardContent>Day and night choices</CardContent>
+            </Card>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(markup).toContain('data-slot="accordion"');
+    expect(markup).toContain('data-slot="accordion-item"');
+    expect(markup).toContain('data-slot="accordion-trigger"');
+    expect(markup).toContain('data-slot="accordion-content"');
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="card-header"');
+    expect(markup).toContain('data-slot="card-title"');
+    expect(markup).toContain('data-slot="card-description"');
+    expect(markup).toContain('data-slot="card-content"');
   });
 });

--- a/src/components/ui/primitives.test.tsx
+++ b/src/components/ui/primitives.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "./dialog";
 import { Input } from "./input";
 import { Label } from "./label";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -81,10 +82,10 @@ describe("workspace ui primitives", () => {
   });
 
   /**
-   * Confirms the additive phase-3 primitives expose stable slots so their no-chrome overrides stay
-   * encapsulated in the shared component layer.
+   * Confirms the additive overlay and form primitives expose stable slots so their no-chrome
+   * overrides stay encapsulated in the shared component layer.
    */
-  it("renders dialog, dropdown menu, tooltip, label, and separator with named slots", () => {
+  it("renders dialog, dropdown menu, tooltip, popover, label, and separator with named slots", () => {
     const markup = renderToStaticMarkup(
       <TooltipProvider>
         <Dialog open>
@@ -106,6 +107,11 @@ describe("workspace ui primitives", () => {
           <TooltipContent>Helpful context</TooltipContent>
         </Tooltip>
 
+        <Popover open>
+          <PopoverTrigger>Tags</PopoverTrigger>
+          <PopoverContent forceMount>Choose tags</PopoverContent>
+        </Popover>
+
         <Label htmlFor="api-key">API key</Label>
         <Input id="api-key" />
         <Separator />
@@ -120,6 +126,7 @@ describe("workspace ui primitives", () => {
     expect(markup).toContain('data-slot="dropdown-menu-item"');
     expect(markup).toContain('data-slot="tooltip-trigger"');
     expect(markup).toContain('data-slot="tooltip-content"');
+    expect(markup).toContain('data-slot="popover-trigger"');
     expect(markup).toContain('data-slot="label"');
     expect(markup).toContain('data-slot="separator"');
   });

--- a/src/components/ui/primitives.test.tsx
+++ b/src/components/ui/primitives.test.tsx
@@ -49,18 +49,18 @@ import {
 
 describe("workspace ui primitives", () => {
   /**
-   * Confirms the shared primitives expose the shadcn-style data slots so later overrides can stay
-   * localized to the component layer instead of leaking through view files.
+   * Confirms the shared primitives expose the shadcn slots while using the stock semantic utility
+   * classes instead of the older Relay-specific surface tokens.
    */
-  it("renders button, input, textarea, and badge with named slots", () => {
+  it("renders button, input, textarea, and badge with stock shadcn utility contracts", () => {
     const markup = renderToStaticMarkup(
       <>
-        <Button size="icon" variant="outline">
+        <Button size="icon" variant="secondary">
           Open
         </Button>
         <Input defaultValue="hello" />
         <Textarea defaultValue="notes" />
-        <Badge variant="secondary">Active</Badge>
+        <Badge variant="outline">Active</Badge>
       </>,
     );
 
@@ -68,6 +68,10 @@ describe("workspace ui primitives", () => {
     expect(markup).toContain('data-slot="input"');
     expect(markup).toContain('data-slot="textarea"');
     expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain("bg-secondary");
+    expect(markup).toContain("border-input");
+    expect(markup).toContain("placeholder:text-muted-foreground");
+    expect(markup).toContain("text-foreground");
     expect(markup).toContain("Active");
   });
 
@@ -95,8 +99,8 @@ describe("workspace ui primitives", () => {
   });
 
   /**
-   * Confirms the additive overlay and form primitives expose stable slots so their no-chrome
-   * overrides stay encapsulated in the shared component layer.
+   * Confirms the additive primitives now expose stock shadcn surface classes instead of the older
+   * custom popover and overlay styling contract.
    */
   it("renders dialog, dropdown menu, tooltip, popover, label, and separator with named slots", () => {
     const markup = renderToStaticMarkup(
@@ -142,6 +146,10 @@ describe("workspace ui primitives", () => {
     expect(markup).toContain('data-slot="popover-trigger"');
     expect(markup).toContain('data-slot="label"');
     expect(markup).toContain('data-slot="separator"');
+    expect(markup).toContain("bg-background");
+    expect(markup).toContain("bg-popover");
+    expect(markup).toContain("bg-primary");
+    expect(markup).toContain("bg-border");
   });
 
   /**

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -5,8 +5,7 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * Provides a shadcn-style Select compound API backed by Radix while keeping Relay's light-touch
- * input styling.
+ * Provides a near-stock shadcn Select compound API while keeping the existing shared import path.
  */
 const Select = SelectPrimitive.Root;
 const SelectGroup = SelectPrimitive.Group;
@@ -19,9 +18,10 @@ const SelectTrigger = React.forwardRef<
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
-        "data-[placeholder]:text-[color:var(--muted)] focus:border-[color:var(--border-strong)] focus:bg-[color:var(--surface)] focus:ring-2 focus:ring-[color:var(--focus-ring)]",
+        "flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow]",
+        "data-[placeholder]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "aria-invalid:border-destructive",
         className,
       )}
       data-slot="select-trigger"
@@ -30,7 +30,7 @@ const SelectTrigger = React.forwardRef<
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDown aria-hidden="true" className="size-4 text-[color:var(--muted)]" />
+        <ChevronDown aria-hidden="true" className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -44,7 +44,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          "relative z-50 max-h-80 min-w-[8rem] overflow-hidden rounded-md border border-[color:var(--border)] bg-[color:var(--popover)] text-[color:var(--popover-foreground)] shadow-md",
+          "relative z-50 max-h-80 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           position === "popper" &&
@@ -78,7 +78,7 @@ const SelectLabel = React.forwardRef<
 >(function SelectLabel({ className, ...props }, ref) {
   return (
     <SelectPrimitive.Label
-      className={cn("px-2 py-1.5 text-xs font-medium uppercase tracking-[0.12em] text-[color:var(--muted)]", className)}
+      className={cn("px-2 py-1.5 text-sm font-semibold", className)}
       data-slot="select-label"
       ref={ref}
       {...props}
@@ -93,8 +93,8 @@ const SelectItem = React.forwardRef<
   return (
     <SelectPrimitive.Item
       className={cn(
-        "relative flex w-full cursor-default select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm outline-none",
-        "data-[highlighted]:bg-[color:var(--surface-muted)] data-[highlighted]:text-[color:var(--foreground)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
       data-slot="select-item"
@@ -117,7 +117,7 @@ const SelectSeparator = React.forwardRef<
 >(function SelectSeparator({ className, ...props }, ref) {
   return (
     <SelectPrimitive.Separator
-      className={cn("my-1 h-px bg-[color:var(--border)]", className)}
+      className={cn("-mx-1 my-1 h-px bg-muted", className)}
       data-slot="select-separator"
       ref={ref}
       {...props}
@@ -131,7 +131,7 @@ const SelectScrollUpButton = React.forwardRef<
 >(function SelectScrollUpButton({ className, ...props }, ref) {
   return (
     <SelectPrimitive.ScrollUpButton
-      className={cn("flex cursor-default items-center justify-center py-1 text-[color:var(--muted)]", className)}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
       data-slot="select-scroll-up-button"
       ref={ref}
       {...props}
@@ -147,7 +147,7 @@ const SelectScrollDownButton = React.forwardRef<
 >(function SelectScrollDownButton({ className, ...props }, ref) {
   return (
     <SelectPrimitive.ScrollDownButton
-      className={cn("flex cursor-default items-center justify-center py-1 text-[color:var(--muted)]", className)}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
       data-slot="select-scroll-down-button"
       ref={ref}
       {...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -13,7 +13,7 @@ const Separator = React.forwardRef<
   return (
     <SeparatorPrimitive.Root
       className={cn(
-        "shrink-0 bg-[color:var(--row-divider)]",
+        "shrink-0 bg-border",
         orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className,
       )}

--- a/src/components/ui/shell-primitives.test.tsx
+++ b/src/components/ui/shell-primitives.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./command";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "./sidebar";
+
+describe("workspace shell primitives", () => {
+  /**
+   * Confirms the shared shell primitives expose stable slots without needing bespoke workspace-only
+   * test coverage for the underlying composition layer.
+   */
+  it("renders command and sidebar primitives with named slots", () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <Command>
+          <CommandInput placeholder="Search" />
+          <CommandList>
+            <CommandItem selected>Inbox</CommandItem>
+            <CommandEmpty>No results</CommandEmpty>
+          </CommandList>
+        </Command>
+
+        <Sidebar aria-label="Workspace sidebar">
+          <SidebarContent>
+            <SidebarGroup>
+              <SidebarGroupLabel>Views</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton isActive>Inbox</SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </SidebarContent>
+        </Sidebar>
+
+        <SidebarRail aria-label="Collapsed workspace sidebar" />
+      </>,
+    );
+
+    expect(markup).toContain('data-slot="command"');
+    expect(markup).toContain('data-slot="command-input"');
+    expect(markup).toContain('data-slot="command-item"');
+    expect(markup).toContain('data-slot="command-empty"');
+    expect(markup).toContain('data-slot="sidebar"');
+    expect(markup).toContain('data-slot="sidebar-content"');
+    expect(markup).toContain('data-slot="sidebar-group-label"');
+    expect(markup).toContain('data-slot="sidebar-menu-button"');
+    expect(markup).toContain('data-slot="sidebar-rail"');
+  });
+});

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,192 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SidebarProps extends React.ComponentPropsWithoutRef<"aside"> {
+  collapsed?: boolean;
+}
+
+const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(function Sidebar(
+  { className, collapsed = false, ...props },
+  ref,
+) {
+  return (
+    <aside
+      className={cn("flex h-full flex-col", className)}
+      data-collapsed={collapsed ? "true" : "false"}
+      data-slot="sidebar"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarHeader = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function SidebarHeader({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn("flex items-center gap-2", className)}
+      data-slot="sidebar-header"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function SidebarContent({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn("flex flex-1 flex-col", className)}
+      data-slot="sidebar-content"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarFooter = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function SidebarFooter({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn("mt-auto", className)}
+      data-slot="sidebar-footer"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarGroup = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"section">
+>(function SidebarGroup({ className, ...props }, ref) {
+  return (
+    <section
+      className={cn("space-y-1", className)}
+      data-slot="sidebar-group"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarGroupLabel = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
+>(function SidebarGroupLabel({ className, ...props }, ref) {
+  return (
+    <p
+      className={cn(
+        "px-2 text-xs font-medium uppercase tracking-[0.22em] text-[color:var(--muted)]",
+        className,
+      )}
+      data-slot="sidebar-group-label"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarGroupContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div">
+>(function SidebarGroupContent({ className, ...props }, ref) {
+  return (
+    <div
+      className={cn(className)}
+      data-slot="sidebar-group-content"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarMenu = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentPropsWithoutRef<"ul">
+>(function SidebarMenu({ className, ...props }, ref) {
+  return (
+    <ul
+      className={cn("space-y-1", className)}
+      data-slot="sidebar-menu"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+const SidebarMenuItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(function SidebarMenuItem({ className, ...props }, ref) {
+  return (
+    <li
+      className={cn(className)}
+      data-slot="sidebar-menu-item"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+interface SidebarMenuButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+  isActive?: boolean;
+}
+
+const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  SidebarMenuButtonProps
+>(function SidebarMenuButton({ className, isActive = false, type = "button", ...props }, ref) {
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors outline-none",
+        "focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
+        isActive
+          ? "bg-[color:var(--row-active)] text-[color:var(--foreground)]"
+          : "text-[color:var(--muted-strong)] hover:bg-[color:var(--row-hover)] hover:text-[color:var(--foreground)]",
+        className,
+      )}
+      data-active={isActive ? "true" : "false"}
+      data-slot="sidebar-menu-button"
+      ref={ref}
+      type={type}
+      {...props}
+    />
+  );
+});
+
+const SidebarRail = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"aside">
+>(function SidebarRail({ className, ...props }, ref) {
+  return (
+    <aside
+      className={cn("flex h-full w-8 shrink-0 border-r border-[color:var(--row-divider)]", className)}
+      data-slot="sidebar-rail"
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -5,17 +5,21 @@ import { cn } from "@/lib/utils";
 /**
  * Gives multiline composers the same shadcn-style structure as Input without adding extra chrome.
  */
-export function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+export const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(function Textarea({ className, ...props }, ref) {
   return (
     <textarea
-      data-slot="textarea"
       className={cn(
         "flex min-h-28 w-full rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
         "placeholder:text-[color:var(--muted)] focus-visible:border-[color:var(--border-strong)] focus-visible:bg-[color:var(--surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
+      data-slot="textarea"
+      ref={ref}
       {...props}
     />
   );
-}
+});

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * Gives multiline composers the same shadcn-style structure as Input without adding extra chrome.
+ * Provides a near-stock shadcn textarea while keeping the existing shared import path.
  */
 export const Textarea = React.forwardRef<
   HTMLTextAreaElement,
@@ -12,9 +12,11 @@ export const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-28 w-full rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
-        "placeholder:text-[color:var(--muted)] focus-visible:border-[color:var(--border-strong)] focus-visible:bg-[color:var(--surface)] focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)]",
-        "disabled:cursor-not-allowed disabled:opacity-50",
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow]",
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "aria-invalid:border-destructive",
         className,
       )}
       data-slot="textarea"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -39,12 +39,12 @@ const TooltipContent = React.forwardRef<
     <TooltipPortal>
       <TooltipPrimitive.Content
         className={cn(
-          "z-50 overflow-hidden rounded-md border border-[color:var(--border)] bg-[color:var(--popover)] px-2.5 py-1.5 text-xs text-[color:var(--popover-foreground)] shadow-sm",
+          "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground shadow-md",
           "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95",
-          "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1",
-          "data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         data-slot="tooltip-content"

--- a/src/features/workspace/agent-configuration-view.test.tsx
+++ b/src/features/workspace/agent-configuration-view.test.tsx
@@ -5,9 +5,10 @@ import { AgentConfigurationView } from "./agent-configuration-view";
 
 describe("agent configuration view", () => {
   /**
-   * Keeps workspace theme and provider controls tucked into a clickable configuration list.
+   * Keeps workspace theme and provider controls tucked into stock accordion sections instead of
+   * custom native details markup.
    */
-  it("renders collapsible configuration sections for theme and agent settings", () => {
+  it("renders accordion sections for theme and agent settings", () => {
     const markup = renderToStaticMarkup(
       <AgentConfigurationView
         activeProvider="openai"
@@ -41,20 +42,24 @@ describe("agent configuration view", () => {
     expect(markup).toContain("Workspace theme");
     expect(markup).toContain("Agent settings");
     expect(markup).toContain('class="text-2xl font-semibold">Configuration</h1>');
-    expect(markup).toContain('class="configuration-disclosure-status">Relay Original / Day</p>');
-    expect(markup).toContain('class="configuration-disclosure-status">API key needed</p>');
-    expect(markup).toContain("configuration-disclosure-meta");
+    expect(markup).toContain("Relay Original / Day");
+    expect(markup).toContain("API key needed");
+    expect(markup).toContain('data-slot="accordion"');
+    expect(markup.match(/data-slot="accordion-item"/g)).toHaveLength(2);
+    expect(markup.match(/data-slot="accordion-trigger"/g)).toHaveLength(2);
+    expect(markup.match(/data-slot="accordion-content"/g)).toHaveLength(2);
     expect(markup).not.toContain("lucide-check");
     expect(markup).not.toContain("text-3xl");
-    expect(markup.match(/<details/g)).toHaveLength(2);
-    expect(markup).not.toContain("<details open");
+    expect(markup).not.toContain("<details");
+    expect(markup).not.toContain("<summary");
+    expect(markup).not.toContain("configuration-disclosure");
     expect(markup).not.toContain("Separate workspace view");
     expect(markup).not.toContain("How this connects to the workspace");
-    expect(markup).not.toContain(
-      'inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em]">Relay Original / Day</div>',
-    );
     expect(markup.match(/aria-label="[^"]+ day theme"/g)).toHaveLength(6);
     expect(markup.match(/aria-label="[^"]+ night theme"/g)).toHaveLength(6);
+    expect(markup).not.toContain("Option 01");
+    expect(markup).not.toContain(">Sun<");
+    expect(markup).not.toContain(">Moon<");
   });
 
   /**
@@ -112,9 +117,7 @@ describe("agent configuration view", () => {
     expect(markup).toContain("Refresh models for Work");
     expect(markup).toContain("Fetch models");
     expect(markup).toContain("Add API key");
-    expect(markup).toContain(
-      'class="configuration-disclosure-status flex items-center justify-end gap-1"',
-    );
+    expect(markup).toContain('data-slot="accordion-content"');
     expect(markup).toContain("lucide-check");
     expect(markup).toContain(">Live provider ready</span>");
     expect(markup).toContain("Only one saved OpenAI key can be active at a time.");
@@ -127,5 +130,6 @@ describe("agent configuration view", () => {
     expect(markup).toContain('data-slot="tooltip-trigger"');
     expect(markup).not.toContain("Save this key");
     expect(markup).not.toContain("lg:grid-cols-[minmax(0,1fr)_minmax(15rem,1.2fr)_auto]");
+    expect(markup).not.toContain("configuration-disclosure-status");
   });
 });

--- a/src/features/workspace/agent-configuration-view.tsx
+++ b/src/features/workspace/agent-configuration-view.tsx
@@ -542,7 +542,7 @@ function ApiKeyManager({
               </p>
             ) : null}
 
-            <Button className="self-end" onClick={handleStartAdd} variant="subtle">
+            <Button className="self-end" onClick={handleStartAdd} variant="secondary">
               <Plus aria-hidden="true" className="size-3.5" />
               Add API key
             </Button>

--- a/src/features/workspace/agent-configuration-view.tsx
+++ b/src/features/workspace/agent-configuration-view.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { useId, useState } from "react";
-import { Check, ChevronDown, Loader2, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Check, Loader2, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -95,35 +101,49 @@ export function AgentConfigurationView({
           until you click into each section.
         </p>
 
-        <ul className="mt-4 space-y-4">
-          <li>
-            <details className="configuration-disclosure rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)]">
-              <ConfigurationDisclosureSummary
+        <Accordion className="mt-4 space-y-4" type="multiple">
+          <AccordionItem
+            className="overflow-hidden rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)]"
+            value="workspace-theme"
+          >
+            <AccordionTrigger className="px-4 py-4 hover:no-underline">
+              <ConfigurationSectionTrigger
                 description="Choose between six paired day and night themes, including Relay Original."
                 statusText={themeSummary}
                 title="Workspace theme"
               />
+            </AccordionTrigger>
 
-              <div className="border-t border-[color:var(--border)] px-4 py-4">
-                <WorkspaceThemeSelector
-                  onSelectTheme={onThemeSelectionChange}
-                  selection={themeSelection}
-                  showHeader={false}
-                />
-              </div>
-            </details>
-          </li>
+            <AccordionContent
+              className="border-t border-[color:var(--border)] px-4 py-4"
+              forceMount
+            >
+              <WorkspaceThemeSelector
+                onSelectTheme={onThemeSelectionChange}
+                selection={themeSelection}
+                showHeader={false}
+              />
+            </AccordionContent>
+          </AccordionItem>
 
-          <li>
-            <details className="configuration-disclosure rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)]">
-              <ConfigurationDisclosureSummary
+          <AccordionItem
+            className="overflow-hidden rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-strong)]"
+            value="agent-settings"
+          >
+            <AccordionTrigger className="px-4 py-4 hover:no-underline">
+              <ConfigurationSectionTrigger
                 description="Add your OpenAI API key and adjust the model used for live thread replies."
                 showsStatusCheckmark={providerSummary.showsCheckmark}
                 statusText={providerSummary.text}
                 title="Agent settings"
               />
+            </AccordionTrigger>
 
-              <div className="space-y-4 border-t border-[color:var(--border)] px-4 py-4">
+            <AccordionContent
+              className="border-t border-[color:var(--border)] px-4 py-4"
+              forceMount
+            >
+              <div className="space-y-4">
                 <ApiKeyManager
                   activeKeyId={activeProviderSettings.activeKeyId}
                   activeProvider={activeProvider}
@@ -148,15 +168,15 @@ export function AgentConfigurationView({
                   storage.
                 </p>
               </div>
-            </details>
-          </li>
-        </ul>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </section>
     </>
   );
 }
 
-interface ConfigurationDisclosureSummaryProps {
+interface ConfigurationSectionTriggerProps {
   description: string;
   showsStatusCheckmark?: boolean;
   statusText: string;
@@ -164,24 +184,24 @@ interface ConfigurationDisclosureSummaryProps {
 }
 
 /**
- * Keeps the disclosure headers readable by using a compact text status instead of summary badges.
+ * Keeps each accordion trigger readable with a compact text summary rather than a heavier preview.
  */
-function ConfigurationDisclosureSummary({
+function ConfigurationSectionTrigger({
   description,
   showsStatusCheckmark = false,
   statusText,
   title,
-}: ConfigurationDisclosureSummaryProps) {
+}: ConfigurationSectionTriggerProps) {
   return (
-    <summary className="configuration-disclosure-summary cursor-pointer list-none px-4 py-4">
-      <div className="configuration-disclosure-copy">
+    <div className="grid min-w-0 flex-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+      <div className="min-w-0">
         <p className="text-sm font-medium">{title}</p>
         <p className="mt-1 max-w-2xl text-sm leading-6 text-[color:var(--muted)]">{description}</p>
       </div>
 
-      <div className="configuration-disclosure-meta">
+      <div className="flex min-w-0 items-start gap-2 sm:pl-4">
         {showsStatusCheckmark ? (
-          <p className="configuration-disclosure-status flex items-center justify-end gap-1">
+          <p className="flex max-w-40 items-center justify-end gap-1 text-right text-xs leading-4 text-[color:var(--muted-strong)]">
             <Check
               aria-hidden="true"
               className="size-3 shrink-0 text-[color:var(--muted-strong)]"
@@ -189,14 +209,12 @@ function ConfigurationDisclosureSummary({
             <span className="min-w-0 truncate">{statusText}</span>
           </p>
         ) : (
-          <p className="configuration-disclosure-status">{statusText}</p>
+          <p className="max-w-40 truncate text-right text-xs leading-4 text-[color:var(--muted-strong)]">
+            {statusText}
+          </p>
         )}
-        <ChevronDown
-          aria-hidden="true"
-          className="configuration-disclosure-chevron size-4 shrink-0 text-[color:var(--muted)]"
-        />
       </div>
-    </summary>
+    </div>
   );
 }
 

--- a/src/features/workspace/agent-thread-panel.test.tsx
+++ b/src/features/workspace/agent-thread-panel.test.tsx
@@ -42,5 +42,6 @@ describe("agent thread panel", () => {
 
     expect(markup.match(/<ul/g)).toHaveLength(1);
     expect(markup).toContain("<li><strong>Option one</strong>: Short explanation.</li>");
+    expect(markup).toContain('data-slot="card"');
   });
 });

--- a/src/features/workspace/archive-view.test.tsx
+++ b/src/features/workspace/archive-view.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ArchiveView } from "./archive-view";
+import { workspaceSeed } from "./mock-data";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("archive view", () => {
+  /**
+   * Verifies the archive now uses card-based day groups and task details while keeping the
+   * existing un-complete workflow intact.
+   */
+  it("renders completed tasks inside archive cards", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-21T12:00:00.000Z"));
+
+    const completedTasks = [
+      {
+        ...workspaceSeed.tasks[0],
+        completed: true,
+        completedAt: "2026-03-21T10:30:00.000Z",
+      },
+    ];
+
+    const markup = renderToStaticMarkup(
+      <ArchiveView
+        completedTasks={completedTasks}
+        onToggleTaskCompleted={vi.fn()}
+        projects={workspaceSeed.projects}
+      />,
+    );
+
+    expect(markup).toContain("Archive");
+    expect(markup).toContain("Today");
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain("Define the smallest possible task manager");
+    expect(markup).toContain('aria-label="Mark incomplete"');
+    expect(markup).toContain("Project: Relay MVP");
+    expect(markup).toContain("planning");
+  });
+
+  /**
+   * Ensures the empty archive state also uses the shared card surface instead of a loose paragraph.
+   */
+  it("renders the empty archive state inside a card", () => {
+    const markup = renderToStaticMarkup(
+      <ArchiveView
+        completedTasks={[]}
+        onToggleTaskCompleted={vi.fn()}
+        projects={workspaceSeed.projects}
+      />,
+    );
+
+    expect(markup).toContain("No completed tasks yet.");
+    expect(markup).toContain('data-slot="card"');
+  });
+});

--- a/src/features/workspace/archive-view.tsx
+++ b/src/features/workspace/archive-view.tsx
@@ -4,7 +4,15 @@ import { useState } from "react";
 
 import { CheckCircle2, ChevronDown, ChevronRight } from "lucide-react";
 
-import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { type Project, type Task } from "@/features/workspace/core";
 import { cn } from "@/lib/utils";
 
@@ -34,7 +42,7 @@ export function ArchiveView({
   const groups = groupTasksByCompletionDay(completedTasks);
 
   return (
-    <>
+    <div className="space-y-6">
       <header>
         <h1 className="text-2xl font-semibold">Archive</h1>
         <p className="mt-1 text-sm text-[color:var(--muted)]">
@@ -45,7 +53,7 @@ export function ArchiveView({
       </header>
 
       {groups.length > 0 ? (
-        <section className="mt-6 space-y-4">
+        <section className="space-y-4">
           {groups.map((group) => (
             <ArchiveDaySection
               group={group}
@@ -55,8 +63,14 @@ export function ArchiveView({
             />
           ))}
         </section>
-      ) : null}
-    </>
+      ) : (
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-32 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+            No completed tasks yet.
+          </CardContent>
+        </Card>
+      )}
+    </div>
   );
 }
 
@@ -77,44 +91,48 @@ function ArchiveDaySection({
   const [isExpanded, setIsExpanded] = useState(true);
 
   return (
-    <section>
-      <button
-        className="flex w-full items-center gap-2 text-left"
-        onClick={() => setIsExpanded((current) => !current)}
-        type="button"
-      >
-        {isExpanded ? (
-          <ChevronDown className="size-3 text-[color:var(--muted)]" />
-        ) : (
-          <ChevronRight className="size-3 text-[color:var(--muted)]" />
-        )}
-        <h3 className="text-xs font-medium uppercase tracking-wide text-[color:var(--muted-strong)]">
-          {group.label}
-          <span className="ml-2 text-[color:var(--muted)]">({group.tasks.length})</span>
-        </h3>
-      </button>
+    <Card>
+      <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle className="text-lg">{group.label}</CardTitle>
+          <CardDescription>
+            {group.tasks.length} completed {group.tasks.length === 1 ? "task" : "tasks"}
+          </CardDescription>
+        </div>
+
+        <Button
+          onClick={() => setIsExpanded((current) => !current)}
+          size="sm"
+          variant="ghost"
+        >
+          {isExpanded ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          )}
+          {isExpanded ? "Hide tasks" : "Show tasks"}
+        </Button>
+      </CardHeader>
 
       {isExpanded ? (
-        <ul className="mt-2">
-          {group.tasks.map((task, index) => (
+        <CardContent className="space-y-3">
+          {group.tasks.map((task) => (
             <ArchiveTaskRow
               key={task.id}
               onToggleTaskCompleted={onToggleTaskCompleted}
               projects={projects}
-              showsSeparator={index < group.tasks.length - 1}
               task={task}
             />
           ))}
-        </ul>
+        </CardContent>
       ) : null}
-    </section>
+    </Card>
   );
 }
 
 interface ArchiveTaskRowProps {
   onToggleTaskCompleted: (taskId: string) => void;
   projects: Project[];
-  showsSeparator: boolean;
   task: Task;
 }
 
@@ -124,7 +142,6 @@ interface ArchiveTaskRowProps {
 function ArchiveTaskRow({
   onToggleTaskCompleted,
   projects,
-  showsSeparator,
   task,
 }: ArchiveTaskRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -132,68 +149,53 @@ function ArchiveTaskRow({
   const completionTime = formatCompletionTime(task.completedAt);
 
   return (
-    <li className="py-2">
-      <div className="pl-[13px]">
-        <div className="flex min-h-8 items-center gap-2">
-          <button
+    <Card className="bg-[color:var(--background)] shadow-none">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-start gap-3">
+          <Button
             aria-label="Mark incomplete"
-            className="shrink-0 transition-colors hover:text-[color:var(--foreground)]"
             onClick={(event) => {
               event.stopPropagation();
               onToggleTaskCompleted(task.id);
             }}
-            type="button"
+            size="icon"
+            variant="ghost"
           >
             <CheckCircle2
               aria-hidden="true"
               className="size-4 fill-[color:var(--border)] text-[color:var(--border-strong)]"
             />
-          </button>
+          </Button>
+
           <button
             className={cn(
-              "flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left",
+              "flex min-w-0 flex-1 flex-col items-start gap-2 text-left",
               "text-[color:var(--muted-strong)] hover:text-[color:var(--foreground)]",
             )}
             onClick={() => setIsExpanded((current) => !current)}
             type="button"
           >
-            <span className="shrink truncate text-sm line-through decoration-[color:var(--muted)]/40">
+            <span className="text-sm font-medium line-through decoration-[color:var(--muted)]/40">
               {task.title}
             </span>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {completionTime ? <Badge>{completionTime}</Badge> : null}
+              {projectName ? <Badge variant="secondary">{`Project: ${projectName}`}</Badge> : null}
+              {task.tags.map((tag) => (
+                <Badge key={tag}>{tag}</Badge>
+              ))}
+            </div>
           </button>
-          {completionTime ? (
-            <span className="shrink-0 text-xs text-[color:var(--muted)]">
-              {completionTime}
-            </span>
-          ) : null}
         </div>
 
         {isExpanded ? (
-          <div className="mt-2 ml-6 space-y-2 text-sm text-[color:var(--muted-strong)]">
-            {task.details ? (
-              <p className="whitespace-pre-wrap">{task.details}</p>
-            ) : null}
-            <div className="flex flex-wrap items-center gap-3 text-xs text-[color:var(--muted)]">
-              {projectName ? <span>Project: {projectName}</span> : null}
-              {task.tags.length > 0 ? (
-                <span className="flex items-center gap-1">
-                  {task.tags.map((tag) => (
-                    <span
-                      className="rounded-full bg-[#9ca3af] px-2 py-px text-xs font-medium leading-none text-white"
-                      key={tag}
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </span>
-              ) : null}
-            </div>
+          <div className="pl-12 text-sm text-[color:var(--muted-strong)]">
+            {task.details ? <p className="whitespace-pre-wrap">{task.details}</p> : null}
           </div>
         ) : null}
-      </div>
-
-      {showsSeparator ? <Separator className="mt-2" /> : null}
-    </li>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/features/workspace/global-search-dialog.test.tsx
+++ b/src/features/workspace/global-search-dialog.test.tsx
@@ -28,9 +28,12 @@ describe("global search dialog", () => {
     expect(markup).toContain("Initiative");
     expect(markup).toContain("Project: Relay MVP");
     expect(markup).toContain("Q2 Product Launch");
+    expect(markup).toContain('data-slot="command"');
+    expect(markup).toContain('data-slot="command-input"');
+    expect(markup).toContain('data-slot="command-item"');
     expect(markup).toContain('data-slot="dialog-content"');
     expect(markup).toContain('data-slot="dialog-title"');
-    expect(markup).toContain('data-slot="separator"');
+    expect(markup).toContain('data-slot="command-separator"');
   });
 
   /**
@@ -52,5 +55,6 @@ describe("global search dialog", () => {
 
     expect(markup).toContain("No matches for");
     expect(markup).toContain("missing result");
+    expect(markup).toContain('data-slot="command-empty"');
   });
 });

--- a/src/features/workspace/global-search.test.ts
+++ b/src/features/workspace/global-search.test.ts
@@ -103,7 +103,7 @@ describe("global search", () => {
     const taskResult = results.find((candidate) => candidate.id === "task-1");
 
     expect(taskResult).toBeDefined();
-    expect(resolveGlobalSearchSelection(taskResult!, workspaceSeed)).toEqual({
+    expect(resolveGlobalSearchSelection(taskResult!)).toEqual({
       activeMenu: "inbox",
       selectedProjectId: null,
       selectedInitiativeId: null,
@@ -119,7 +119,7 @@ describe("global search", () => {
     const projectResult = results.find((candidate) => candidate.id === "project-1");
 
     expect(projectResult).toBeDefined();
-    expect(resolveGlobalSearchSelection(projectResult!, workspaceSeed)).toEqual({
+    expect(resolveGlobalSearchSelection(projectResult!)).toEqual({
       activeMenu: "projects",
       selectedProjectId: "project-1",
       selectedInitiativeId: null,
@@ -135,7 +135,7 @@ describe("global search", () => {
     const projectResult = results.find((candidate) => candidate.id === "project-2");
 
     expect(projectResult).toBeDefined();
-    expect(resolveGlobalSearchSelection(projectResult!, workspaceSeed)).toEqual({
+    expect(resolveGlobalSearchSelection(projectResult!)).toEqual({
       activeMenu: "projects",
       selectedProjectId: "project-2",
       selectedInitiativeId: null,
@@ -156,7 +156,7 @@ describe("global search", () => {
     }
 
     expect(initiativeResult).toBeDefined();
-    expect(resolveGlobalSearchSelection(initiativeResult!, workspaceSeed)).toEqual({
+    expect(resolveGlobalSearchSelection(initiativeResult!)).toEqual({
       activeMenu: "initiatives",
       selectedProjectId: null,
       selectedInitiativeId: "initiative-1",

--- a/src/features/workspace/inbox-view.tsx
+++ b/src/features/workspace/inbox-view.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import { CheckCircle2, Circle } from "lucide-react";
 
 import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 import {
   filterVisibleProjects,
   isTaskInInbox,

--- a/src/features/workspace/initiative-view.test.tsx
+++ b/src/features/workspace/initiative-view.test.tsx
@@ -50,6 +50,8 @@ describe("initiative view", () => {
     expect(markup).not.toContain("Define the smallest possible task manager");
     expect(markup).toContain("1 project");
     expect(markup).not.toContain("1 projects");
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain('class="text-2xl font-semibold tracking-tight">Initiatives</h1>');
     expect(markup).not.toContain("Workspace view");
     expect(markup).not.toContain(
@@ -98,8 +100,9 @@ describe("initiative view", () => {
     expect(markup).toContain("Initiative thread");
     expect(markup).toContain("Show thread (2)");
     expect(markup).toContain('aria-label="Initiative actions"');
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain('data-slot="dropdown-menu-trigger"');
-    expect(markup).toContain('data-slot="separator"');
     expect(markup).toContain('class="mt-2 text-2xl font-semibold tracking-tight">Q2 Product Launch</h1>');
     expect(markup).not.toContain("text-3xl");
   });

--- a/src/features/workspace/initiative-view.tsx
+++ b/src/features/workspace/initiative-view.tsx
@@ -3,7 +3,16 @@
 import { useState } from "react";
 import { ArrowLeft, MoreHorizontal, Plus } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,7 +21,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import {
   type Initiative,
@@ -32,7 +40,8 @@ interface InitiativeViewProps {
 }
 
 /**
- * Renders initiatives as a text-forward list so hierarchy comes from spacing and copy.
+ * Renders initiatives as stock-style cards so strategic metadata and linked projects stay readable
+ * without a bespoke row layout.
  */
 export function InitiativeView({
   initiatives,
@@ -70,7 +79,7 @@ export function InitiativeView({
         <Button
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
-          variant={isComposerExpanded ? "subtle" : "ghost"}
+          variant={isComposerExpanded ? "outline" : "ghost"}
         >
           <Plus className="size-4" />
           Add initiative
@@ -78,25 +87,35 @@ export function InitiativeView({
       </header>
 
       {isComposerExpanded ? (
-        <section className="grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-          <Input
-            autoFocus
-            onChange={(event) => setNewName(event.target.value)}
-            placeholder="Initiative name"
-            value={newName}
-          />
-          <Input
-            onChange={(event) => setNewDeadline(event.target.value)}
-            placeholder="Deadline"
-            type="date"
-            value={newDeadline}
-          />
-          <Textarea
-            onChange={(event) => setNewDescription(event.target.value)}
-            placeholder="Description"
-            value={newDescription}
-          />
-          <div className="flex justify-end gap-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">New initiative</CardTitle>
+            <CardDescription>
+              Add the strategic container first, then attach projects underneath it.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="grid gap-3">
+            <Input
+              autoFocus
+              onChange={(event) => setNewName(event.target.value)}
+              placeholder="Initiative name"
+              value={newName}
+            />
+            <Input
+              onChange={(event) => setNewDeadline(event.target.value)}
+              placeholder="Deadline"
+              type="date"
+              value={newDeadline}
+            />
+            <Textarea
+              onChange={(event) => setNewDescription(event.target.value)}
+              placeholder="Description"
+              value={newDescription}
+            />
+          </CardContent>
+
+          <CardFooter className="justify-end gap-2">
             <Button
               onClick={() => {
                 setIsComposerExpanded(false);
@@ -111,67 +130,76 @@ export function InitiativeView({
             <Button disabled={!newName.trim()} onClick={handleAdd}>
               Save initiative
             </Button>
-          </div>
-        </section>
+          </CardFooter>
+        </Card>
       ) : null}
 
       {initiatives.length === 0 ? (
-        <p className="text-sm text-[color:var(--muted)]">
-          No initiatives yet. Add one to create strategic context for your projects.
-        </p>
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-32 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+            No initiatives yet. Add one to create strategic context for your projects.
+          </CardContent>
+        </Card>
       ) : (
-        <section>
-          {initiatives.map((initiative, index) => {
+        <section className="grid gap-4 xl:grid-cols-2">
+          {initiatives.map((initiative) => {
             const childProjects = projects.filter(
               (project) => project.initiativeId === initiative.id,
             );
 
             return (
-              <div key={initiative.id}>
-                {index > 0 ? <Separator /> : null}
-                <button
-                  className="group block w-full py-4 text-left transition-colors hover:bg-[color:var(--row-hover)]"
-                  onClick={() => onSelectInitiative(initiative.id)}
-                  type="button"
-                >
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                        <p className="text-sm font-medium text-[color:var(--foreground)]">
-                          {initiative.name}
-                        </p>
-                        <p className="text-xs text-[color:var(--muted)]">
-                          {readProjectCountLabel(childProjects.length)}
-                        </p>
-                        <p className="text-xs text-[color:var(--muted)]">
-                          {initiative.deadline
-                            ? `Due ${formatDeadline(initiative.deadline)}`
-                            : "No deadline"}
-                        </p>
-                        <p className="text-xs text-[color:var(--muted)]">
-                          {initiative.agentThread.messages.length} messages
-                        </p>
-                      </div>
-
-                      <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--muted)] line-clamp-2">
-                        {initiative.description || "No description yet."}
-                      </p>
-
-                      {childProjects.length > 0 ? (
-                        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-[color:var(--muted)]">
-                          {childProjects.slice(0, 2).map((project) => (
-                            <span key={project.id}>{project.name}</span>
-                          ))}
-                        </div>
-                      ) : null}
+              <button
+                className="group block h-full w-full text-left"
+                key={initiative.id}
+                onClick={() => onSelectInitiative(initiative.id)}
+                type="button"
+              >
+                <Card className="flex h-full flex-col transition-colors group-hover:border-[color:var(--border-strong)] group-hover:bg-[color:var(--surface-muted)]">
+                  <CardHeader className="gap-4">
+                    <div className="flex flex-wrap gap-2">
+                      <Badge>{readProjectCountLabel(childProjects.length)}</Badge>
+                      <Badge>
+                        {initiative.deadline
+                          ? `Due ${formatDeadline(initiative.deadline)}`
+                          : "No deadline"}
+                      </Badge>
+                      <Badge variant="secondary">
+                        {initiative.agentThread.messages.length} messages
+                      </Badge>
                     </div>
 
-                    <span className="shrink-0 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)] transition-colors group-hover:text-[color:var(--foreground)]">
-                      Open
+                    <div className="space-y-2">
+                      <CardTitle className="text-lg">{initiative.name}</CardTitle>
+                      <CardDescription className="line-clamp-2 leading-6">
+                        {initiative.description || "No description yet."}
+                      </CardDescription>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent className="space-y-3">
+                    <p className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
+                      Linked projects
+                    </p>
+                    {childProjects.length > 0 ? (
+                      <ul className="space-y-2 text-sm text-[color:var(--muted-strong)]">
+                        {childProjects.slice(0, 2).map((project) => (
+                          <li key={project.id}>{project.name}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-[color:var(--muted)]">
+                        No linked projects yet.
+                      </p>
+                    )}
+                  </CardContent>
+
+                  <CardFooter className="mt-auto justify-end">
+                    <span className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)] transition-colors group-hover:text-[color:var(--foreground)]">
+                      Open initiative
                     </span>
-                  </div>
-                </button>
-              </div>
+                  </CardFooter>
+                </Card>
+              </button>
             );
           })}
         </section>
@@ -198,7 +226,8 @@ interface InitiativeDetailViewProps {
 }
 
 /**
- * Renders the selected initiative as a minimal detail view with linked projects beneath it.
+ * Renders the selected initiative as a card-based detail view with linked projects and thread
+ * context grouped into shared surface sections.
  */
 export function InitiativeDetailView({
   activeProviderLabel,
@@ -314,63 +343,79 @@ function InitiativeDetailContent({
 
   return (
     <div className="space-y-8">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="min-w-0">
-          <Button onClick={onBack} variant="ghost">
-            <ArrowLeft className="size-4" />
-            Back to initiatives
-          </Button>
-          <p className="mt-5 text-xs font-medium uppercase tracking-[0.24em] text-[color:var(--muted)]">
-            Initiative detail
-          </p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight">
-            {activeInitiative.name}
-          </h1>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--muted)]">
-            {activeInitiative.description || "No description yet for this initiative."}
-          </p>
-          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm text-[color:var(--muted)]">
-            <span>{readProjectCountLabel(childProjects.length)}</span>
-            <span>
+      <Card>
+        <CardHeader className="gap-6 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0 space-y-4">
+            <Button onClick={onBack} variant="ghost">
+              <ArrowLeft className="size-4" />
+              Back to initiatives
+            </Button>
+
+            <div className="space-y-2">
+              <Badge variant="secondary">Initiative detail</Badge>
+              <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+                {activeInitiative.name}
+              </h1>
+              <CardDescription className="max-w-3xl leading-6">
+                {activeInitiative.description || "No description yet for this initiative."}
+              </CardDescription>
+            </div>
+          </div>
+
+          <InitiativeActionsMenu
+            isEditing={isEditing}
+            onDeleteInitiative={() => {
+              if (confirm("Delete this initiative? Projects will be unlinked.")) {
+                onDeleteInitiative(activeInitiative.id);
+                onBack();
+              }
+            }}
+            onToggleEdit={() => setIsEditing((currentValue) => !currentValue)}
+          />
+        </CardHeader>
+
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            <Badge>{readProjectCountLabel(childProjects.length)}</Badge>
+            <Badge>
               {activeInitiative.deadline
                 ? `Due ${formatDeadline(activeInitiative.deadline)}`
                 : "No deadline"}
-            </span>
-            <span>{activeInitiative.agentThread.messages.length} saved messages</span>
+            </Badge>
+            <Badge variant="secondary">
+              {activeInitiative.agentThread.messages.length} saved messages
+            </Badge>
           </div>
-        </div>
-
-        <InitiativeActionsMenu
-          isEditing={isEditing}
-          onDeleteInitiative={() => {
-            if (confirm("Delete this initiative? Projects will be unlinked.")) {
-              onDeleteInitiative(activeInitiative.id);
-              onBack();
-            }
-          }}
-          onToggleEdit={() => setIsEditing((currentValue) => !currentValue)}
-        />
-      </div>
+        </CardContent>
+      </Card>
 
       {isEditing ? (
-        <section className="grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-          <Input
-            autoFocus
-            onChange={(event) => setEditName(event.target.value)}
-            placeholder="Initiative name"
-            value={editName}
-          />
-          <Input
-            onChange={(event) => setEditDeadline(event.target.value)}
-            type="date"
-            value={editDeadline}
-          />
-          <Textarea
-            onChange={(event) => setEditDescription(event.target.value)}
-            placeholder="Description"
-            value={editDescription}
-          />
-          <div className="flex justify-end gap-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Edit initiative</CardTitle>
+            <CardDescription>Update the strategic context from one shared form.</CardDescription>
+          </CardHeader>
+
+          <CardContent className="grid gap-3">
+            <Input
+              autoFocus
+              onChange={(event) => setEditName(event.target.value)}
+              placeholder="Initiative name"
+              value={editName}
+            />
+            <Input
+              onChange={(event) => setEditDeadline(event.target.value)}
+              type="date"
+              value={editDeadline}
+            />
+            <Textarea
+              onChange={(event) => setEditDescription(event.target.value)}
+              placeholder="Description"
+              value={editDescription}
+            />
+          </CardContent>
+
+          <CardFooter className="justify-end gap-2">
             <Button
               onClick={() => {
                 setIsEditing(false);
@@ -385,100 +430,115 @@ function InitiativeDetailContent({
             <Button disabled={!editName.trim()} onClick={handleSaveInitiative}>
               Save changes
             </Button>
-          </div>
-        </section>
+          </CardFooter>
+        </Card>
       ) : null}
 
-      <section className="pt-6">
-        <Separator className="mb-6" />
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Projects inside this initiative</h2>
-            <p className="mt-1 text-sm text-[color:var(--muted)]">
+            <CardTitle className="text-xl">Projects inside this initiative</CardTitle>
+            <CardDescription>
               Keep linked projects easy to scan and easy to open.
-            </p>
+            </CardDescription>
           </div>
           <Button
             onClick={() => setIsProjectComposerOpen((currentValue) => !currentValue)}
-            variant={isProjectComposerOpen ? "subtle" : "ghost"}
+            variant={isProjectComposerOpen ? "outline" : "ghost"}
           >
             <Plus className="size-4" />
             Add project
           </Button>
-        </div>
+        </CardHeader>
 
-        {isProjectComposerOpen ? (
-          <div className="mt-4 grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-            <Input
-              autoFocus
-              onChange={(event) => setNewProjectName(event.target.value)}
-              placeholder="Project name"
-              value={newProjectName}
-            />
-            <Input
-              onChange={(event) => setNewProjectDeadline(event.target.value)}
-              placeholder="Deadline"
-              type="date"
-              value={newProjectDeadline}
-            />
-            <div className="flex justify-end gap-2">
-              <Button
-                onClick={() => {
-                  setIsProjectComposerOpen(false);
-                  setNewProjectName("");
-                  setNewProjectDeadline("");
-                }}
-                variant="ghost"
-              >
-                Cancel
-              </Button>
-              <Button disabled={!newProjectName.trim()} onClick={handleAddProject}>
-                Save project
-              </Button>
-            </div>
-          </div>
-        ) : null}
+        <CardContent className="space-y-4">
+          {isProjectComposerOpen ? (
+            <Card className="border-dashed bg-[color:var(--background)] shadow-none">
+              <CardHeader>
+                <CardTitle className="text-base">New project</CardTitle>
+                <CardDescription>
+                  Add a project directly into this initiative.
+                </CardDescription>
+              </CardHeader>
 
-        {childProjects.length === 0 ? (
-          <p className="mt-4 text-sm text-[color:var(--muted)]">
-            No projects linked to this initiative yet.
-          </p>
-        ) : (
-          <div className="mt-4">
-            {childProjects.map((project, index) => (
-              <div key={project.id}>
-                {index > 0 ? <Separator /> : null}
+              <CardContent className="grid gap-3">
+                <Input
+                  autoFocus
+                  onChange={(event) => setNewProjectName(event.target.value)}
+                  placeholder="Project name"
+                  value={newProjectName}
+                />
+                <Input
+                  onChange={(event) => setNewProjectDeadline(event.target.value)}
+                  placeholder="Deadline"
+                  type="date"
+                  value={newProjectDeadline}
+                />
+              </CardContent>
+
+              <CardFooter className="justify-end gap-2">
+                <Button
+                  onClick={() => {
+                    setIsProjectComposerOpen(false);
+                    setNewProjectName("");
+                    setNewProjectDeadline("");
+                  }}
+                  variant="ghost"
+                >
+                  Cancel
+                </Button>
+                <Button disabled={!newProjectName.trim()} onClick={handleAddProject}>
+                  Save project
+                </Button>
+              </CardFooter>
+            </Card>
+          ) : null}
+
+          {childProjects.length === 0 ? (
+            <Card className="border-dashed bg-[color:var(--background)] shadow-none">
+              <CardContent className="flex min-h-24 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+                No projects linked to this initiative yet.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {childProjects.map((project) => (
                 <button
-                  className="group flex w-full items-start justify-between gap-3 py-4 text-left transition-colors hover:bg-[color:var(--row-hover)]"
+                  className="group block w-full text-left"
+                  key={project.id}
                   onClick={() => onSelectProject(project.id)}
                   type="button"
                 >
-                  <div className="min-w-0">
-                    <h3 className="text-sm font-medium text-[color:var(--foreground)]">
-                      {project.name}
-                    </h3>
-                    <p className="mt-2 text-sm text-[color:var(--muted)]">
-                      {project.deadline ? `Due ${formatDeadline(project.deadline)}` : "No deadline"}
-                    </p>
-                  </div>
-                  <span className="shrink-0 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)] transition-colors group-hover:text-[color:var(--foreground)]">
-                    Open project
-                  </span>
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
+                  <Card className="transition-colors group-hover:border-[color:var(--border-strong)] group-hover:bg-[color:var(--surface-muted)]">
+                    <CardHeader className="gap-4">
+                      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="min-w-0">
+                          <CardTitle className="text-base">{project.name}</CardTitle>
+                          <CardDescription className="mt-2">
+                            {project.deadline
+                              ? `Due ${formatDeadline(project.deadline)}`
+                              : "No deadline"}
+                          </CardDescription>
+                        </div>
 
-      <section className="pt-6">
-        <Separator className="mb-6" />
-        <div className="flex items-center justify-between gap-3">
+                        <Badge variant="secondary">Open project</Badge>
+                      </div>
+                    </CardHeader>
+                  </Card>
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Initiative thread</h2>
-            <p className="mt-1 text-sm text-[color:var(--muted)]">
+            <CardTitle className="text-xl">Initiative thread</CardTitle>
+            <CardDescription>
               Strategic context stays close without boxing in the whole page.
-            </p>
+            </CardDescription>
           </div>
           <Button
             onClick={() => setIsThreadOpen((currentValue) => !currentValue)}
@@ -488,10 +548,10 @@ function InitiativeDetailContent({
               ? "Hide thread"
               : `Show thread (${activeInitiative.agentThread.messages.length})`}
           </Button>
-        </div>
+        </CardHeader>
 
         {isThreadOpen ? (
-          <div className="mt-4">
+          <CardContent>
             <AgentThreadPanel
               activeProviderLabel={activeProviderLabel}
               activeProviderModel={activeProviderModel}
@@ -508,9 +568,9 @@ function InitiativeDetailContent({
               onSend={() => onSendThreadMessage(activeInitiative.id)}
               thread={activeInitiative.agentThread}
             />
-          </div>
+          </CardContent>
         ) : null}
-      </section>
+      </Card>
     </div>
   );
 }

--- a/src/features/workspace/initiative-view.tsx
+++ b/src/features/workspace/initiative-view.tsx
@@ -79,7 +79,8 @@ export function InitiativeView({
         <Button
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
-          variant={isComposerExpanded ? "outline" : "ghost"}
+          variant={isComposerExpanded ? "secondary" : "ghost"}
+          variant={isComposerExpanded ? "secondary" : "ghost"}
         >
           <Plus className="size-4" />
           Add initiative
@@ -444,7 +445,8 @@ function InitiativeDetailContent({
           </div>
           <Button
             onClick={() => setIsProjectComposerOpen((currentValue) => !currentValue)}
-            variant={isProjectComposerOpen ? "outline" : "ghost"}
+            variant={isProjectComposerOpen ? "secondary" : "ghost"}
+            variant={isProjectComposerOpen ? "secondary" : "ghost"}
           >
             <Plus className="size-4" />
             Add project

--- a/src/features/workspace/initiative-view.tsx
+++ b/src/features/workspace/initiative-view.tsx
@@ -80,7 +80,6 @@ export function InitiativeView({
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
           variant={isComposerExpanded ? "secondary" : "ghost"}
-          variant={isComposerExpanded ? "secondary" : "ghost"}
         >
           <Plus className="size-4" />
           Add initiative
@@ -445,7 +444,6 @@ function InitiativeDetailContent({
           </div>
           <Button
             onClick={() => setIsProjectComposerOpen((currentValue) => !currentValue)}
-            variant={isProjectComposerOpen ? "secondary" : "ghost"}
             variant={isProjectComposerOpen ? "secondary" : "ghost"}
           >
             <Plus className="size-4" />

--- a/src/features/workspace/navigation/workspace-collapsed-rail.tsx
+++ b/src/features/workspace/navigation/workspace-collapsed-rail.tsx
@@ -2,13 +2,14 @@
 
 import { PanelLeftOpen } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+import { SidebarRail } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 
 interface WorkspaceCollapsedRailProps {
   onExpand: () => void;
@@ -20,27 +21,25 @@ interface WorkspaceCollapsedRailProps {
 export function WorkspaceCollapsedRail({ onExpand }: WorkspaceCollapsedRailProps) {
   return (
     <TooltipProvider>
-      <aside
+      <SidebarRail
         aria-label="Collapsed workspace sidebar"
-        className="workspace-collapsed-rail flex h-full w-8 shrink-0 border-r border-[color:var(--row-divider)]"
+        className="workspace-collapsed-rail"
       >
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
+            <Button
               aria-label="Expand sidebar"
-              className={cn(
-                "flex h-12 w-full items-center justify-center text-[color:var(--muted)] transition-colors",
-                "hover:bg-[color:var(--row-hover)] hover:text-[color:var(--foreground)]",
-              )}
+              className="h-12 w-full rounded-none text-[color:var(--muted)]"
               onClick={onExpand}
-              type="button"
+              size="icon"
+              variant="ghost"
             >
               <PanelLeftOpen className="size-4" />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="right">Expand sidebar</TooltipContent>
         </Tooltip>
-      </aside>
+      </SidebarRail>
     </TooltipProvider>
   );
 }

--- a/src/features/workspace/navigation/workspace-sidebar.tsx
+++ b/src/features/workspace/navigation/workspace-sidebar.tsx
@@ -13,7 +13,20 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -48,7 +61,8 @@ interface WorkspaceSidebarProps {
 }
 
 /**
- * Renders the left navigation shell as a thin list-first layer instead of a framed panel.
+ * Rebuilds the workspace sidebar with stock shadcn-style sidebar composition while keeping the
+ * existing navigation state and quiet Relay presentation.
  */
 export function WorkspaceSidebar({
   activeMenu,
@@ -71,11 +85,11 @@ export function WorkspaceSidebar({
 
   return (
     <TooltipProvider>
-      <aside
+      <Sidebar
         aria-label="Workspace sidebar"
-        className="workspace-sidebar-shell flex h-full flex-col border-r border-[color:var(--row-divider)] pr-5"
+        className="workspace-sidebar-shell border-r border-[color:var(--row-divider)] pr-5"
       >
-        <div className="flex justify-end pb-4">
+        <SidebarHeader className="justify-end pb-4">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -90,23 +104,27 @@ export function WorkspaceSidebar({
             </TooltipTrigger>
             <TooltipContent side="right">Hide sidebar</TooltipContent>
           </Tooltip>
-        </div>
+        </SidebarHeader>
 
-        <nav aria-label="Workspace destinations" className="flex flex-1 flex-col gap-6">
-          <section className="space-y-1">
-            <p className="px-2 text-xs font-medium uppercase tracking-[0.22em] text-[color:var(--muted)]">
-              Views
-            </p>
-            <SidebarMenuButton
-              active={activeMenu === "inbox"}
-              hint={readWorkspaceMenuHint("inbox")}
-              icon={<Inbox className="size-4" />}
-              label={readWorkspaceMenuLabel("inbox")}
-              onClick={() => onSelectMenu("inbox")}
-            />
-          </section>
+        <SidebarContent className="gap-6">
+          <SidebarGroup>
+            <SidebarGroupLabel>Views</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <WorkspaceSidebarMenuButton
+                    active={activeMenu === "inbox"}
+                    hint={readWorkspaceMenuHint("inbox")}
+                    icon={<Inbox className="size-4" />}
+                    label={readWorkspaceMenuLabel("inbox")}
+                    onClick={() => onSelectMenu("inbox")}
+                  />
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
 
-          <SidebarSection
+          <WorkspaceSidebarSection
             active={activeMenu === "projects" && selectedProjectId === null}
             icon={<FolderKanban className="size-4" />}
             isExpanded={isProjectsExpanded}
@@ -117,17 +135,18 @@ export function WorkspaceSidebar({
             toggleLabel={projectsToggleLabel}
           >
             {visibleProjects.map((project) => (
-              <SidebarChildButton
-                active={selectedProjectId === project.id}
-                key={project.id}
-                label={project.name}
-                onClick={() => onSelectProject(project.id)}
-              />
+              <SidebarMenuItem key={project.id}>
+                <WorkspaceSidebarChildButton
+                  active={selectedProjectId === project.id}
+                  label={project.name}
+                  onClick={() => onSelectProject(project.id)}
+                />
+              </SidebarMenuItem>
             ))}
-          </SidebarSection>
+          </WorkspaceSidebarSection>
 
           {featureFlags.initiatives ? (
-            <SidebarSection
+            <WorkspaceSidebarSection
               active={activeMenu === "initiatives" && selectedInitiativeId === null}
               icon={<Sparkles className="size-4" />}
               isExpanded={isInitiativesExpanded}
@@ -138,43 +157,54 @@ export function WorkspaceSidebar({
               toggleLabel={initiativesToggleLabel}
             >
               {initiatives.map((initiative) => (
-                <SidebarChildButton
-                  active={selectedInitiativeId === initiative.id}
-                  key={initiative.id}
-                  label={initiative.name}
-                  onClick={() => onSelectInitiative(initiative.id)}
-                />
+                <SidebarMenuItem key={initiative.id}>
+                  <WorkspaceSidebarChildButton
+                    active={selectedInitiativeId === initiative.id}
+                    label={initiative.name}
+                    onClick={() => onSelectInitiative(initiative.id)}
+                  />
+                </SidebarMenuItem>
               ))}
-            </SidebarSection>
+            </WorkspaceSidebarSection>
           ) : null}
 
-          <section className="space-y-1">
-            <SidebarMenuButton
-              active={activeMenu === "archive"}
-              hint={readWorkspaceMenuHint("archive")}
-              icon={<Archive className="size-4" />}
-              label={readWorkspaceMenuLabel("archive")}
-              onClick={() => onSelectMenu("archive")}
-            />
-          </section>
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <WorkspaceSidebarMenuButton
+                    active={activeMenu === "archive"}
+                    hint={readWorkspaceMenuHint("archive")}
+                    icon={<Archive className="size-4" />}
+                    label={readWorkspaceMenuLabel("archive")}
+                    onClick={() => onSelectMenu("archive")}
+                  />
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
 
-          <div className="mt-auto pt-4">
-            <Separator className="mb-4" />
-            <SidebarMenuButton
-              active={activeMenu === "configuration"}
-              hint={readWorkspaceMenuHint("configuration")}
-              icon={<Settings2 className="size-4" />}
-              label={readWorkspaceMenuLabel("configuration")}
-              onClick={() => onSelectMenu("configuration")}
-            />
-          </div>
-        </nav>
-      </aside>
+        <SidebarFooter className="pt-4">
+          <Separator className="mb-4" />
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <WorkspaceSidebarMenuButton
+                active={activeMenu === "configuration"}
+                hint={readWorkspaceMenuHint("configuration")}
+                icon={<Settings2 className="size-4" />}
+                label={readWorkspaceMenuLabel("configuration")}
+                onClick={() => onSelectMenu("configuration")}
+              />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
     </TooltipProvider>
   );
 }
 
-interface SidebarMenuButtonProps {
+interface WorkspaceSidebarMenuButtonProps {
   active: boolean;
   hint: string;
   icon: ReactNode;
@@ -182,24 +212,19 @@ interface SidebarMenuButtonProps {
   onClick: () => void;
 }
 
-function SidebarMenuButton({
+function WorkspaceSidebarMenuButton({
   active,
   hint,
   icon,
   label,
   onClick,
-}: SidebarMenuButtonProps) {
+}: WorkspaceSidebarMenuButtonProps) {
   return (
-    <button
+    <SidebarMenuButton
       aria-current={active ? "page" : undefined}
-      className={cn(
-        "flex w-full items-start gap-3 rounded-md px-2 py-2 text-left transition-colors",
-        active
-          ? "bg-[color:var(--row-active)] text-[color:var(--foreground)]"
-          : "text-[color:var(--muted-strong)] hover:bg-[color:var(--row-hover)] hover:text-[color:var(--foreground)]",
-      )}
+      className="items-start"
+      isActive={active}
       onClick={onClick}
-      type="button"
     >
       <span
         className={cn(
@@ -213,11 +238,11 @@ function SidebarMenuButton({
         <span className="block text-sm font-medium">{label}</span>
         <span className="mt-1 block text-xs text-[color:var(--muted)]">{hint}</span>
       </span>
-    </button>
+    </SidebarMenuButton>
   );
 }
 
-interface SidebarSectionProps {
+interface WorkspaceSidebarSectionProps {
   active: boolean;
   children: ReactNode;
   icon: ReactNode;
@@ -229,7 +254,7 @@ interface SidebarSectionProps {
   toggleLabel: string;
 }
 
-function SidebarSection({
+function WorkspaceSidebarSection({
   active,
   children,
   icon,
@@ -239,86 +264,81 @@ function SidebarSection({
   onToggle,
   title,
   toggleLabel,
-}: SidebarSectionProps) {
+}: WorkspaceSidebarSectionProps) {
   return (
-    <section className="space-y-2">
-      <div className="flex items-start gap-2">
-        <button
-          aria-current={active ? "page" : undefined}
-          className={cn(
-            "flex min-w-0 flex-1 items-start gap-3 rounded-md px-2 py-2 text-left transition-colors",
-            active
-              ? "bg-[color:var(--row-active)] text-[color:var(--foreground)]"
-              : "text-[color:var(--muted-strong)] hover:bg-[color:var(--row-hover)] hover:text-[color:var(--foreground)]",
-          )}
-          onClick={onSelect}
-          type="button"
-        >
-          <span
-            className={cn(
-              "mt-0.5 shrink-0 text-[color:var(--muted)]",
-              active && "text-[color:var(--foreground)]",
-            )}
+    <Collapsible open={isExpanded}>
+      <SidebarGroup className="space-y-2">
+        <div className="flex items-start gap-2">
+          <SidebarMenuButton
+            aria-current={active ? "page" : undefined}
+            className="min-w-0 flex-1 items-start"
+            isActive={active}
+            onClick={onSelect}
           >
-            {icon}
-          </span>
-          <span className="min-w-0">
-            <span className="block text-sm font-medium">{title}</span>
-            <span className="mt-1 block text-xs text-[color:var(--muted)]">
-              {itemCount} {itemCount === 1 ? title.slice(0, -1).toLowerCase() : title.toLowerCase()}
-            </span>
-          </span>
-        </button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              aria-expanded={isExpanded}
-              aria-label={toggleLabel}
-              className="mt-0.5 shrink-0"
-              onClick={onToggle}
-              size="icon"
-              variant="ghost"
-            >
-              {isExpanded ? (
-                <ChevronDown className="size-4" />
-              ) : (
-                <ChevronRight className="size-4" />
+            <span
+              className={cn(
+                "mt-0.5 shrink-0 text-[color:var(--muted)]",
+                active && "text-[color:var(--foreground)]",
               )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{toggleLabel}</TooltipContent>
-        </Tooltip>
-      </div>
+            >
+              {icon}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium">{title}</span>
+              <span className="mt-1 block text-xs text-[color:var(--muted)]">
+                {itemCount} {itemCount === 1 ? title.slice(0, -1).toLowerCase() : title.toLowerCase()}
+              </span>
+            </span>
+          </SidebarMenuButton>
 
-      {isExpanded ? (
-        <div className="ml-4 border-l border-[color:var(--row-divider)] pl-4">
-          <div className="space-y-0.5">{children}</div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-expanded={isExpanded}
+                aria-label={toggleLabel}
+                className="mt-0.5 shrink-0"
+                onClick={onToggle}
+                size="icon"
+                variant="ghost"
+              >
+                {isExpanded ? (
+                  <ChevronDown className="size-4" />
+                ) : (
+                  <ChevronRight className="size-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">{toggleLabel}</TooltipContent>
+          </Tooltip>
         </div>
-      ) : null}
-    </section>
+
+        <CollapsibleContent className="ml-4 border-l border-[color:var(--row-divider)] pl-4">
+          <SidebarMenu className="space-y-0.5">{children}</SidebarMenu>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
   );
 }
 
-interface SidebarChildButtonProps {
+interface WorkspaceSidebarChildButtonProps {
   active: boolean;
   label: string;
   onClick: () => void;
 }
 
-function SidebarChildButton({ active, label, onClick }: SidebarChildButtonProps) {
+function WorkspaceSidebarChildButton({
+  active,
+  label,
+  onClick,
+}: WorkspaceSidebarChildButtonProps) {
   return (
-    <button
+    <SidebarMenuButton
       aria-current={active ? "page" : undefined}
-      className={cn(
-        "flex w-full items-center rounded-md px-2 py-2 text-left transition-colors",
-        active
-          ? "bg-[color:var(--row-active)] text-[color:var(--foreground)]"
-          : "text-[color:var(--muted-strong)] hover:bg-[color:var(--row-hover)] hover:text-[color:var(--foreground)]",
-      )}
+      className="py-2"
+      isActive={active}
       onClick={onClick}
-      type="button"
     >
       <span className="truncate text-xs font-medium">{label}</span>
-    </button>
+    </SidebarMenuButton>
   );
 }

--- a/src/features/workspace/navigation/workspace-top-menu.tsx
+++ b/src/features/workspace/navigation/workspace-top-menu.tsx
@@ -1,82 +1,91 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 import {
   type WorkspaceMenu,
+  readWorkspaceMenuHint,
   readWorkspaceMenuLabel,
   workspaceMenus,
 } from "./workspace-navigation";
 
 interface WorkspaceTopMenuProps {
   activeMenu: WorkspaceMenu;
-  isExpanded: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
   onSelectMenu: (menu: WorkspaceMenu) => void;
-  onToggleMenu: () => void;
 }
 
 /**
- * Renders a slim desktop top menu that opens from the current-view label.
+ * Uses a stock shadcn dropdown-menu pattern for top-level workspace navigation.
  */
 export function WorkspaceTopMenu({
   activeMenu,
-  isExpanded,
+  isOpen,
+  onOpenChange,
   onSelectMenu,
-  onToggleMenu,
 }: WorkspaceTopMenuProps) {
   return (
-    <section className="workspace-top-menu-shell pb-2">
-      <div className="flex items-center gap-3 text-sm">
-        <Button
-          aria-controls="workspace-top-menu"
-          aria-expanded={isExpanded}
-          aria-haspopup="true"
-          className="shrink-0 -ml-3 transition-all duration-150 hover:opacity-80 active:scale-95"
-          onClick={onToggleMenu}
-          size="sm"
-          variant="ghost"
-        >
-          <span className="text-sm">{readWorkspaceMenuLabel(activeMenu)}</span>
-          <ChevronDown
-            className={cn(
-              "size-4 transition-transform duration-150",
-              isExpanded ? "rotate-180" : "",
-            )}
-          />
-        </Button>
-      </div>
+    <section className="workspace-top-menu-shell">
+      <DropdownMenu onOpenChange={onOpenChange} open={isOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label="Open workspace navigation"
+            className="shrink-0 -ml-3"
+            size="sm"
+            variant="ghost"
+          >
+            <span className="text-sm">{readWorkspaceMenuLabel(activeMenu)}</span>
+            <ChevronDown
+              className={cn(
+                "size-4 transition-transform duration-150",
+                isOpen ? "rotate-180" : "",
+              )}
+            />
+          </Button>
+        </DropdownMenuTrigger>
 
-      {isExpanded ? (
-        <nav
-          aria-label="Workspace menu"
-          className="mt-2 flex flex-wrap gap-3 text-sm"
-          id="workspace-top-menu"
-        >
+        <DropdownMenuContent align="start" className="w-72">
+          <DropdownMenuLabel>Navigate</DropdownMenuLabel>
+          <DropdownMenuSeparator />
           {workspaceMenus.map((menu) => {
             const isActive = activeMenu === menu;
 
             return (
-              <button
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "text-left transition-all duration-150 cursor-pointer active:opacity-70",
-                  isActive
-                    ? "font-medium text-[color:var(--foreground)]"
-                    : "text-[color:var(--muted)] hover:text-[color:var(--foreground)]",
-                )}
+              <DropdownMenuItem
+                className="items-start gap-3 py-2"
                 key={menu}
-                onClick={() => onSelectMenu(menu)}
-                type="button"
+                onSelect={() => onSelectMenu(menu)}
               >
-                {readWorkspaceMenuLabel(menu)}
-              </button>
+                <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+                  {isActive ? <Check className="size-4" /> : null}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">
+                    {readWorkspaceMenuLabel(menu)}
+                  </span>
+                  <span className="mt-1 block text-xs text-[color:var(--muted)]">
+                    {readWorkspaceMenuHint(menu)}
+                  </span>
+                </span>
+                {isActive ? <DropdownMenuShortcut>Current</DropdownMenuShortcut> : null}
+              </DropdownMenuItem>
             );
           })}
-        </nav>
-      ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </section>
   );
 }

--- a/src/features/workspace/project-view.test.tsx
+++ b/src/features/workspace/project-view.test.tsx
@@ -76,6 +76,8 @@ describe("project view", () => {
     expect(markup).toContain("Define the smallest possible task manager");
     expect(markup).toContain("List the next three product decisions");
     expect(markup).toContain("0 messages");
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain('class="text-2xl font-semibold tracking-tight">Projects</h1>');
     expect(markup).not.toContain("Workspace view");
     expect(markup).not.toContain(
@@ -99,8 +101,9 @@ describe("project view", () => {
     expect(markup).toContain("Show thread (0)");
     expect(markup).toContain('aria-label="Open task Define the smallest possible task manager"');
     expect(markup).toContain('aria-label="Project actions"');
+    expect(markup).toContain('data-slot="card"');
+    expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain('data-slot="dropdown-menu-trigger"');
-    expect(markup).toContain('data-slot="separator"');
     expect(markup).toContain('class="mt-2 text-2xl font-semibold tracking-tight">Relay MVP</h1>');
     expect(markup).not.toContain("text-3xl");
   });

--- a/src/features/workspace/project-view.tsx
+++ b/src/features/workspace/project-view.tsx
@@ -4,7 +4,16 @@ import { useState } from "react";
 import { ArrowLeft, MoreHorizontal, Plus } from "lucide-react";
 
 import { featureFlags } from "@/features/feature-flags";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,7 +23,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import {
   filterVisibleProjects,
@@ -42,7 +50,8 @@ interface ProjectViewProps {
 }
 
 /**
- * Renders the projects overview as a quiet list of rows rather than a grid of cards.
+ * Renders the projects overview as stock-style cards so project metadata and previews stay
+ * readable without a bespoke row treatment.
  */
 export function ProjectView({
   initiatives,
@@ -82,7 +91,7 @@ export function ProjectView({
         <Button
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
-          variant={isComposerExpanded ? "subtle" : "ghost"}
+          variant={isComposerExpanded ? "outline" : "ghost"}
         >
           <Plus className="size-4" />
           Add project
@@ -90,38 +99,48 @@ export function ProjectView({
       </header>
 
       {isComposerExpanded ? (
-        <section className="grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-          <Input
-            autoFocus
-            onChange={(event) => setNewName(event.target.value)}
-            placeholder="Project name"
-            value={newName}
-          />
-          {featureFlags.initiatives ? (
-            <Select
-              onValueChange={(value) => setNewInitiativeId(value === "_none" ? "" : value)}
-              value={newInitiativeId || "_none"}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="No initiative" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="_none">No initiative</SelectItem>
-                {initiatives.map((initiative) => (
-                  <SelectItem key={initiative.id} value={initiative.id}>
-                    {initiative.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : null}
-          <Input
-            onChange={(event) => setNewDeadline(event.target.value)}
-            placeholder="Deadline"
-            type="date"
-            value={newDeadline}
-          />
-          <div className="flex justify-end gap-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">New project</CardTitle>
+            <CardDescription>
+              Add a project and optionally connect it to an initiative right away.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="grid gap-3">
+            <Input
+              autoFocus
+              onChange={(event) => setNewName(event.target.value)}
+              placeholder="Project name"
+              value={newName}
+            />
+            {featureFlags.initiatives ? (
+              <Select
+                onValueChange={(value) => setNewInitiativeId(value === "_none" ? "" : value)}
+                value={newInitiativeId || "_none"}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No initiative" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_none">No initiative</SelectItem>
+                  {initiatives.map((initiative) => (
+                    <SelectItem key={initiative.id} value={initiative.id}>
+                      {initiative.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
+            <Input
+              onChange={(event) => setNewDeadline(event.target.value)}
+              placeholder="Deadline"
+              type="date"
+              value={newDeadline}
+            />
+          </CardContent>
+
+          <CardFooter className="justify-end gap-2">
             <Button
               onClick={() => {
                 setIsComposerExpanded(false);
@@ -136,17 +155,19 @@ export function ProjectView({
             <Button disabled={!newName.trim()} onClick={handleAdd}>
               Save project
             </Button>
-          </div>
-        </section>
+          </CardFooter>
+        </Card>
       ) : null}
 
       {visibleProjects.length === 0 ? (
-        <p className="text-sm text-[color:var(--muted)]">
-          No projects yet. Add one to create a new destination in the sidebar.
-        </p>
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-32 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+            No projects yet. Add one to create a new destination in the sidebar.
+          </CardContent>
+        </Card>
       ) : (
-        <section>
-          {visibleProjects.map((project, index) => {
+        <section className="grid gap-4 xl:grid-cols-2">
+          {visibleProjects.map((project) => {
             const projectInitiative = project.initiativeId
               ? initiatives.find((initiative) => initiative.id === project.initiativeId) ?? null
               : null;
@@ -154,58 +175,67 @@ export function ProjectView({
             const canUseProjectThread = supportsProjectThread(project.id);
 
             return (
-              <div key={project.id}>
-                {index > 0 ? <Separator /> : null}
-                <button
-                  className="group block w-full py-4 text-left transition-colors hover:bg-[color:var(--row-hover)]"
-                  onClick={() => onSelectProject(project.id)}
-                  type="button"
-                >
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                        <p className="text-sm font-medium text-[color:var(--foreground)]">
-                          {project.name}
-                        </p>
-                        {featureFlags.initiatives ? (
-                          <p className="text-xs text-[color:var(--muted)]">
-                            {projectInitiative ? projectInitiative.name : "No initiative"}
-                          </p>
-                        ) : null}
-                        <p className="text-xs text-[color:var(--muted)]">
-                          {readTaskCountLabel(projectTasks.length)}
-                        </p>
-                        <p className="text-xs text-[color:var(--muted)]">
-                          {project.deadline
-                            ? `Due ${formatDeadline(project.deadline)}`
-                            : "No deadline"}
-                        </p>
-                        {canUseProjectThread ? (
-                          <p className="text-xs text-[color:var(--muted)]">
-                            {project.agentThread.messages.length} messages
-                          </p>
-                        ) : null}
-                      </div>
-
-                      {projectTasks.length > 0 ? (
-                        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-[color:var(--muted)]">
-                          {projectTasks.slice(0, 2).map((task) => (
-                            <span key={task.id}>{task.title}</span>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="mt-2 text-sm text-[color:var(--muted)]">
-                          No tasks linked yet.
-                        </p>
-                      )}
+              <button
+                className="group block h-full w-full text-left"
+                key={project.id}
+                onClick={() => onSelectProject(project.id)}
+                type="button"
+              >
+                <Card className="flex h-full flex-col transition-colors group-hover:border-[color:var(--border-strong)] group-hover:bg-[color:var(--surface-muted)]">
+                  <CardHeader className="gap-4">
+                    <div className="flex flex-wrap gap-2">
+                      {featureFlags.initiatives ? (
+                        <Badge variant="secondary">
+                          {projectInitiative ? projectInitiative.name : "No initiative"}
+                        </Badge>
+                      ) : null}
+                      <Badge>{readTaskCountLabel(projectTasks.length)}</Badge>
+                      <Badge>
+                        {project.deadline
+                          ? `Due ${formatDeadline(project.deadline)}`
+                          : "No deadline"}
+                      </Badge>
+                      {canUseProjectThread ? (
+                        <Badge variant="secondary">
+                          {project.agentThread.messages.length} messages
+                        </Badge>
+                      ) : null}
                     </div>
 
-                    <span className="shrink-0 text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)] transition-colors group-hover:text-[color:var(--foreground)]">
-                      Open
+                    <div className="space-y-2">
+                      <CardTitle className="text-lg">{project.name}</CardTitle>
+                      <CardDescription>
+                        {projectTasks.length > 0
+                          ? "Open the project to edit tasks and keep thread context nearby."
+                          : "No tasks linked yet. Open the project to add the first one."}
+                      </CardDescription>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent className="space-y-3">
+                    <p className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
+                      Task preview
+                    </p>
+                    {projectTasks.length > 0 ? (
+                      <ul className="space-y-2 text-sm text-[color:var(--muted-strong)]">
+                        {projectTasks.slice(0, 2).map((task) => (
+                          <li key={task.id}>{task.title}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-[color:var(--muted)]">
+                        No tasks linked yet.
+                      </p>
+                    )}
+                  </CardContent>
+
+                  <CardFooter className="mt-auto justify-end">
+                    <span className="text-xs font-medium uppercase tracking-[0.16em] text-[color:var(--muted)] transition-colors group-hover:text-[color:var(--foreground)]">
+                      Open project
                     </span>
-                  </div>
-                </button>
-              </div>
+                  </CardFooter>
+                </Card>
+              </button>
             );
           })}
         </section>
@@ -247,7 +277,8 @@ interface ProjectDetailViewProps {
 }
 
 /**
- * Renders one selected project as a focused center-page detail view with minimal framing.
+ * Renders one selected project as a card-based detail view that keeps tasks and thread context
+ * together without bespoke panel styles.
  */
 export function ProjectDetailView({
   activeProviderLabel,
@@ -420,86 +451,107 @@ function ProjectDetailContent({
 
   return (
     <div className="space-y-8">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="min-w-0">
-          <Button onClick={onBack} variant="ghost">
-            <ArrowLeft className="size-4" />
-            Back to projects
-          </Button>
-          <p className="mt-5 text-xs font-medium uppercase tracking-[0.24em] text-[color:var(--muted)]">
-            Project detail
-          </p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight">{activeProject.name}</h1>
-          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm text-[color:var(--muted)]">
-            <span>{readTaskCountLabel(childTasks.length)}</span>
-            <span>
+      <Card>
+        <CardHeader className="gap-6 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0 space-y-4">
+            <Button onClick={onBack} variant="ghost">
+              <ArrowLeft className="size-4" />
+              Back to projects
+            </Button>
+
+            <div className="space-y-2">
+              <Badge variant="secondary">Project detail</Badge>
+              <h1 className="mt-2 text-2xl font-semibold tracking-tight">{activeProject.name}</h1>
+              <CardDescription>
+                Keep tasks, deadlines, initiative links, and thread history inside one stock
+                workspace surface.
+              </CardDescription>
+            </div>
+          </div>
+
+          <ProjectActionsMenu
+            canDelete={!isPermanentProjectId(activeProject.id)}
+            isEditing={isEditing}
+            onDeleteProject={() => {
+              if (confirm("Delete this project? Tasks will be moved to No Project.")) {
+                onDeleteProject(activeProject.id);
+                onBack();
+              }
+            }}
+            onToggleEdit={() => setIsEditing((currentValue) => !currentValue)}
+          />
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Badge>{readTaskCountLabel(childTasks.length)}</Badge>
+            <Badge>
               {activeProject.deadline
                 ? `Due ${formatDeadline(activeProject.deadline)}`
                 : "No deadline"}
-            </span>
+            </Badge>
             {featureFlags.initiatives ? (
-              <span>
+              <Badge variant="secondary">
                 {linkedInitiative ? `Initiative: ${linkedInitiative.name}` : "No initiative"}
-              </span>
+              </Badge>
             ) : null}
             {canUseProjectThread ? (
-              <span>{activeProject.agentThread.messages.length} saved messages</span>
+              <Badge variant="secondary">
+                {activeProject.agentThread.messages.length} saved messages
+              </Badge>
             ) : null}
           </div>
+
           {featureFlags.initiatives && linkedInitiative ? (
-            <div className="mt-4">
-              <Button onClick={() => onOpenInitiative(linkedInitiative.id)} variant="ghost">
+            <div>
+              <Button onClick={() => onOpenInitiative(linkedInitiative.id)} variant="outline">
                 Open initiative
               </Button>
             </div>
           ) : null}
-        </div>
-
-        <ProjectActionsMenu
-          canDelete={!isPermanentProjectId(activeProject.id)}
-          isEditing={isEditing}
-          onDeleteProject={() => {
-            if (confirm("Delete this project? Tasks will be moved to No Project.")) {
-              onDeleteProject(activeProject.id);
-              onBack();
-            }
-          }}
-          onToggleEdit={() => setIsEditing((currentValue) => !currentValue)}
-        />
-      </div>
+        </CardContent>
+      </Card>
 
       {isEditing ? (
-        <section className="grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-          <Input
-            autoFocus
-            onChange={(event) => setEditName(event.target.value)}
-            placeholder="Project name"
-            value={editName}
-          />
-          {featureFlags.initiatives ? (
-            <Select
-              onValueChange={(value) => setEditInitiativeId(value === "_none" ? "" : value)}
-              value={editInitiativeId || "_none"}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="No initiative" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="_none">No initiative</SelectItem>
-                {initiatives.map((initiative) => (
-                  <SelectItem key={initiative.id} value={initiative.id}>
-                    {initiative.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : null}
-          <Input
-            onChange={(event) => setEditDeadline(event.target.value)}
-            type="date"
-            value={editDeadline}
-          />
-          <div className="flex justify-end gap-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Edit project</CardTitle>
+            <CardDescription>Update the core project metadata from one shared form.</CardDescription>
+          </CardHeader>
+
+          <CardContent className="grid gap-3">
+            <Input
+              autoFocus
+              onChange={(event) => setEditName(event.target.value)}
+              placeholder="Project name"
+              value={editName}
+            />
+            {featureFlags.initiatives ? (
+              <Select
+                onValueChange={(value) => setEditInitiativeId(value === "_none" ? "" : value)}
+                value={editInitiativeId || "_none"}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No initiative" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_none">No initiative</SelectItem>
+                  {initiatives.map((initiative) => (
+                    <SelectItem key={initiative.id} value={initiative.id}>
+                      {initiative.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
+            <Input
+              onChange={(event) => setEditDeadline(event.target.value)}
+              type="date"
+              value={editDeadline}
+            />
+          </CardContent>
+
+          <CardFooter className="justify-end gap-2">
             <Button
               onClick={() => {
                 setIsEditing(false);
@@ -514,104 +566,115 @@ function ProjectDetailContent({
             <Button disabled={!editName.trim()} onClick={handleSaveProject}>
               Save changes
             </Button>
-          </div>
-        </section>
+          </CardFooter>
+        </Card>
       ) : null}
 
-      <section className="pt-6">
-        <Separator className="mb-6" />
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Tasks in this project</h2>
-            <p className="mt-1 text-sm text-[color:var(--muted)]">
+            <CardTitle className="text-xl">Tasks in this project</CardTitle>
+            <CardDescription>
               Keep the task list readable and editable without leaving the project page.
-            </p>
+            </CardDescription>
           </div>
           <Button
             onClick={() => setIsTaskComposerOpen((currentValue) => !currentValue)}
-            variant={isTaskComposerOpen ? "subtle" : "ghost"}
+            variant={isTaskComposerOpen ? "outline" : "ghost"}
           >
             <Plus className="size-4" />
             Add task
           </Button>
-        </div>
+        </CardHeader>
 
-        {isTaskComposerOpen ? (
-          <div className="mt-4 grid gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4">
-            <Input
-              autoFocus
-              onChange={(event) => setNewTaskTitle(event.target.value)}
-              placeholder="Task title"
-              value={newTaskTitle}
-            />
-            <Textarea
-              onChange={(event) => setNewTaskDetails(event.target.value)}
-              placeholder="Task details"
-              value={newTaskDetails}
-            />
-            <Input
-              onChange={(event) => setNewTaskTags(event.target.value)}
-              placeholder="Tags (comma-separated)"
-              value={newTaskTags}
-            />
-            <div className="flex justify-end gap-2">
-              <Button
-                onClick={() => {
-                  setIsTaskComposerOpen(false);
-                  setNewTaskTitle("");
-                  setNewTaskDetails("");
-                  setNewTaskTags("");
-                }}
-                variant="ghost"
-              >
-                Cancel
-              </Button>
-              <Button disabled={!newTaskTitle.trim()} onClick={handleAddTask}>
-                Save task
-              </Button>
+        <CardContent className="space-y-4">
+          {isTaskComposerOpen ? (
+            <Card className="border-dashed bg-[color:var(--background)] shadow-none">
+              <CardHeader>
+                <CardTitle className="text-base">New task</CardTitle>
+                <CardDescription>Add a task without leaving the project detail view.</CardDescription>
+              </CardHeader>
+
+              <CardContent className="grid gap-3">
+                <Input
+                  autoFocus
+                  onChange={(event) => setNewTaskTitle(event.target.value)}
+                  placeholder="Task title"
+                  value={newTaskTitle}
+                />
+                <Textarea
+                  onChange={(event) => setNewTaskDetails(event.target.value)}
+                  placeholder="Task details"
+                  value={newTaskDetails}
+                />
+                <Input
+                  onChange={(event) => setNewTaskTags(event.target.value)}
+                  placeholder="Tags (comma-separated)"
+                  value={newTaskTags}
+                />
+              </CardContent>
+
+              <CardFooter className="justify-end gap-2">
+                <Button
+                  onClick={() => {
+                    setIsTaskComposerOpen(false);
+                    setNewTaskTitle("");
+                    setNewTaskDetails("");
+                    setNewTaskTags("");
+                  }}
+                  variant="ghost"
+                >
+                  Cancel
+                </Button>
+                <Button disabled={!newTaskTitle.trim()} onClick={handleAddTask}>
+                  Save task
+                </Button>
+              </CardFooter>
+            </Card>
+          ) : null}
+
+          {childTasks.length === 0 ? (
+            <Card className="border-dashed bg-[color:var(--background)] shadow-none">
+              <CardContent className="flex min-h-24 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+                No tasks yet for this project.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {childTasks.map((task) => (
+                <ProjectTaskRow
+                  allTags={allTaskTags}
+                  editDetails={editDetails}
+                  editingTaskId={editingTaskId}
+                  editProject={editProject}
+                  editTags={editTags}
+                  editTitle={editTitle}
+                  key={task.id}
+                  onCancelEdit={onCancelEdit}
+                  onDeleteTask={onDeleteTask}
+                  onOpenTask={onOpenTask}
+                  onSaveEdit={onSaveEdit}
+                  onSetEditDetails={onSetEditDetails}
+                  onSetEditProject={onSetEditProject}
+                  onSetEditTags={onSetEditTags}
+                  onSetEditTitle={onSetEditTitle}
+                  projects={visibleProjects}
+                  task={task}
+                />
+              ))}
             </div>
-          </div>
-        ) : null}
-
-        {childTasks.length === 0 ? (
-          <p className="mt-4 text-sm text-[color:var(--muted)]">No tasks yet for this project.</p>
-        ) : (
-          <div className="mt-4">
-            {childTasks.map((task, index) => (
-              <ProjectTaskRow
-                allTags={allTaskTags}
-                editDetails={editDetails}
-                editingTaskId={editingTaskId}
-                editProject={editProject}
-                editTags={editTags}
-                editTitle={editTitle}
-                key={task.id}
-                onCancelEdit={onCancelEdit}
-                onDeleteTask={onDeleteTask}
-                onOpenTask={onOpenTask}
-                onSaveEdit={onSaveEdit}
-                onSetEditDetails={onSetEditDetails}
-                onSetEditProject={onSetEditProject}
-                onSetEditTags={onSetEditTags}
-                onSetEditTitle={onSetEditTitle}
-                projects={visibleProjects}
-                showsSeparator={index > 0}
-                task={task}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+          )}
+        </CardContent>
+      </Card>
 
       {canUseProjectThread ? (
-        <section className="pt-6">
-          <Separator className="mb-6" />
-          <div className="flex items-center justify-between gap-3">
+        <Card>
+          <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <h2 className="text-xl font-semibold">Project thread</h2>
-              <p className="mt-1 text-sm text-[color:var(--muted)]">
+              <CardTitle className="text-xl">Project thread</CardTitle>
+              <CardDescription>
                 Keep agent context nearby without turning it into another dashboard panel.
-              </p>
+              </CardDescription>
             </div>
             <Button
               onClick={() => setIsThreadOpen((currentValue) => !currentValue)}
@@ -621,10 +684,10 @@ function ProjectDetailContent({
                 ? "Hide thread"
                 : `Show thread (${activeProject.agentThread.messages.length})`}
             </Button>
-          </div>
+          </CardHeader>
 
           {isThreadOpen ? (
-            <div className="mt-4">
+            <CardContent>
               <AgentThreadPanel
                 activeProviderLabel={activeProviderLabel}
                 activeProviderModel={activeProviderModel}
@@ -641,9 +704,9 @@ function ProjectDetailContent({
                 onSend={() => onSendThreadMessage(activeProject.id)}
                 thread={activeProject.agentThread}
               />
-            </div>
+            </CardContent>
           ) : null}
-        </section>
+        </Card>
       ) : null}
     </div>
   );
@@ -665,13 +728,12 @@ interface ProjectTaskRowProps {
   onSetEditTags: (value: string) => void;
   onSetEditTitle: (value: string) => void;
   projects: Project[];
-  showsSeparator: boolean;
   task: Task;
 }
 
 /**
- * Keeps project detail task entries lightweight while allowing one task to expand inline for
- * editing without replacing the rest of the list.
+ * Keeps project detail task entries inside shared card surfaces while allowing one task to expand
+ * inline for editing without replacing the rest of the list.
  */
 function ProjectTaskRow({
   allTags,
@@ -689,14 +751,12 @@ function ProjectTaskRow({
   onSetEditTags,
   onSetEditTitle,
   projects,
-  showsSeparator,
   task,
 }: ProjectTaskRowProps) {
-  return (
-    <div>
-      {showsSeparator ? <Separator /> : null}
-      {task.id === editingTaskId ? (
-        <div className="py-4">
+  if (task.id === editingTaskId) {
+    return (
+      <Card className="border-dashed bg-[color:var(--background)] shadow-none">
+        <CardContent className="px-4 pb-4 pt-4">
           <TaskInlineEditor
             allTags={allTags}
             editDetails={editDetails}
@@ -713,45 +773,39 @@ function ProjectTaskRow({
             projects={projects}
             task={task}
           />
-        </div>
-      ) : (
-        <button
-          aria-label={`Open task ${task.title}`}
-          className="group block w-full py-4 text-left transition-colors hover:bg-[color:var(--row-hover)]"
-          onClick={() => onOpenTask(task.id)}
-          type="button"
-        >
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <button
+      aria-label={`Open task ${task.title}`}
+      className="group block w-full text-left"
+      onClick={() => onOpenTask(task.id)}
+      type="button"
+    >
+      <Card className="transition-colors group-hover:border-[color:var(--border-strong)] group-hover:bg-[color:var(--surface-muted)]">
+        <CardHeader className="gap-4">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0">
-              <h3 className="text-sm font-medium text-[color:var(--foreground)]">
-                {task.title}
-              </h3>
-              {task.details ? (
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--muted)]">
-                  {task.details}
-                </p>
-              ) : (
-                <p className="mt-2 text-sm text-[color:var(--muted)]">No details yet.</p>
-              )}
+              <CardTitle className="text-base">{task.title}</CardTitle>
+              <CardDescription className="mt-2 max-w-2xl leading-6">
+                {task.details || "No details yet."}
+              </CardDescription>
             </div>
 
-            <div className="shrink-0 text-sm text-[color:var(--muted)]">
+            <div className="flex shrink-0 flex-wrap justify-start gap-2 lg:justify-end">
               {task.tags.length > 0 ? (
-                <div className="flex flex-wrap justify-start gap-x-3 gap-y-1 lg:justify-end">
-                  {task.tags.map((tag) => (
-                    <span key={tag}>#{tag}</span>
-                  ))}
-                </div>
+                task.tags.map((tag) => <Badge key={tag}>#{tag}</Badge>)
               ) : (
-                <span className="text-xs font-medium uppercase tracking-[0.16em] transition-colors group-hover:text-[color:var(--foreground)]">
-                  Open
-                </span>
+                <Badge variant="secondary">Open</Badge>
               )}
             </div>
           </div>
-        </button>
-      )}
-    </div>
+        </CardHeader>
+      </Card>
+    </button>
   );
 }
 

--- a/src/features/workspace/project-view.tsx
+++ b/src/features/workspace/project-view.tsx
@@ -91,7 +91,8 @@ export function ProjectView({
         <Button
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
-          variant={isComposerExpanded ? "outline" : "ghost"}
+          variant={isComposerExpanded ? "secondary" : "ghost"}
+          variant={isComposerExpanded ? "secondary" : "ghost"}
         >
           <Plus className="size-4" />
           Add project
@@ -580,7 +581,8 @@ function ProjectDetailContent({
           </div>
           <Button
             onClick={() => setIsTaskComposerOpen((currentValue) => !currentValue)}
-            variant={isTaskComposerOpen ? "outline" : "ghost"}
+            variant={isTaskComposerOpen ? "secondary" : "ghost"}
+            variant={isTaskComposerOpen ? "secondary" : "ghost"}
           >
             <Plus className="size-4" />
             Add task

--- a/src/features/workspace/project-view.tsx
+++ b/src/features/workspace/project-view.tsx
@@ -92,7 +92,6 @@ export function ProjectView({
           aria-expanded={isComposerExpanded}
           onClick={() => setIsComposerExpanded((currentValue) => !currentValue)}
           variant={isComposerExpanded ? "secondary" : "ghost"}
-          variant={isComposerExpanded ? "secondary" : "ghost"}
         >
           <Plus className="size-4" />
           Add project
@@ -581,7 +580,6 @@ function ProjectDetailContent({
           </div>
           <Button
             onClick={() => setIsTaskComposerOpen((currentValue) => !currentValue)}
-            variant={isTaskComposerOpen ? "secondary" : "ghost"}
             variant={isTaskComposerOpen ? "secondary" : "ghost"}
           >
             <Plus className="size-4" />

--- a/src/features/workspace/search/global-search-dialog.tsx
+++ b/src/features/workspace/search/global-search-dialog.tsx
@@ -3,14 +3,21 @@
 import { type KeyboardEvent } from "react";
 
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 
 import {
   cycleGlobalSearchIndex,
@@ -86,8 +93,8 @@ export function GlobalSearchDialog({
           Search tasks, projects, and initiatives.
         </DialogDescription>
 
-        <div className="p-3">
-          <Input
+        <Command>
+          <CommandInput
             aria-label="Global search"
             autoFocus
             onChange={(event) => onQueryChange(event.target.value)}
@@ -95,31 +102,22 @@ export function GlobalSearchDialog({
             placeholder="Search tasks, projects, and initiatives..."
             value={query}
           />
-        </div>
 
-        <Separator />
-
-        <div className="max-h-[24rem] overflow-y-auto p-2">
-          {results.length === 0 ? (
-            <p className="rounded-md px-3 py-6 text-sm text-[color:var(--muted)]">
-              {query.trim()
-                ? `No matches for "${query.trim()}".`
-                : "No searchable items yet."}
-            </p>
-          ) : (
-            <ul className="space-y-1">
-              {results.map((result, index) => (
-                <li key={`${result.entityType}-${result.id}`}>
-                  <button
-                    className={cn(
-                      "w-full rounded-lg border px-3 py-3 text-left transition",
-                      activeIndex === index
-                        ? "border-[color:var(--foreground)] bg-[color:var(--surface-strong)]"
-                        : "border-transparent hover:border-[color:var(--border)] hover:bg-[color:var(--surface-strong)]",
-                    )}
+          <CommandList>
+            {results.length === 0 ? (
+              <CommandEmpty>
+                {query.trim()
+                  ? `No matches for "${query.trim()}".`
+                  : "No searchable items yet."}
+              </CommandEmpty>
+            ) : (
+              <CommandGroup heading="Results">
+                {results.map((result, index) => (
+                  <CommandItem
+                    key={`${result.entityType}-${result.id}`}
                     onClick={() => onSelectResult(result)}
                     onMouseEnter={() => onActiveIndexChange(index)}
-                    type="button"
+                    selected={activeIndex === index}
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
@@ -139,19 +137,25 @@ export function GlobalSearchDialog({
                         {readGlobalSearchEntityLabel(result.entityType)}
                       </span>
                     </div>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
 
-        <Separator />
+          <CommandSeparator />
 
-        <div className="px-3 py-2 text-xs text-[color:var(--muted)]">
-          Use <kbd>↑</kbd> <kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to open, and <kbd>Esc</kbd>{" "}
-          to close.
-        </div>
+          <div className="flex flex-wrap items-center gap-3 px-3 py-2 text-xs text-[color:var(--muted)]">
+            <span>Use</span>
+            <CommandShortcut>↑</CommandShortcut>
+            <CommandShortcut>↓</CommandShortcut>
+            <span>to navigate,</span>
+            <CommandShortcut>Enter</CommandShortcut>
+            <span>to open, and</span>
+            <CommandShortcut>Esc</CommandShortcut>
+            <span>to close.</span>
+          </div>
+        </Command>
       </DialogContent>
     </Dialog>
   );

--- a/src/features/workspace/search/global-search.ts
+++ b/src/features/workspace/search/global-search.ts
@@ -154,7 +154,6 @@ export function cycleGlobalSearchIndex(
  */
 export function resolveGlobalSearchSelection(
   result: GlobalSearchResult,
-  _workspace: WorkspaceSnapshot,
 ): SearchNavigationIntent {
   switch (result.entityType) {
     case "task":

--- a/src/features/workspace/search/global-search.ts
+++ b/src/features/workspace/search/global-search.ts
@@ -154,10 +154,7 @@ export function cycleGlobalSearchIndex(
  */
 export function resolveGlobalSearchSelection(
   result: GlobalSearchResult,
-  workspace: WorkspaceSnapshot,
 ): SearchNavigationIntent {
-  void workspace;
-
   switch (result.entityType) {
     case "task":
       return {

--- a/src/features/workspace/search/global-search.ts
+++ b/src/features/workspace/search/global-search.ts
@@ -154,7 +154,10 @@ export function cycleGlobalSearchIndex(
  */
 export function resolveGlobalSearchSelection(
   result: GlobalSearchResult,
+  workspace: WorkspaceSnapshot,
 ): SearchNavigationIntent {
+  void workspace;
+
   switch (result.entityType) {
     case "task":
       return {

--- a/src/features/workspace/task-management-view.tsx
+++ b/src/features/workspace/task-management-view.tsx
@@ -138,7 +138,7 @@ export function TaskManagementView({
           aria-expanded={isComposerExpanded}
           onClick={handleExpandComposer}
           size="sm"
-          variant={isComposerExpanded ? "subtle" : "ghost"}
+          variant={isComposerExpanded ? "secondary" : "ghost"}
         >
           <Plus className="size-4" />
           Add task

--- a/src/features/workspace/task-management-view.tsx
+++ b/src/features/workspace/task-management-view.tsx
@@ -5,17 +5,14 @@ import { useState } from "react";
 import { CheckCircle2, Circle, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
 import {
   filterVisibleProjects,
-  inboxPickerLabel,
 } from "@/features/workspace/projects";
 import { cn } from "@/lib/utils";
 import {
   collectTaskTags,
+  TaskEditorFields,
   groupTasksByProject,
   groupTasksByTag,
   TaskInlineEditor,
@@ -136,65 +133,36 @@ export function TaskManagementView({
         ) : null}
       </header>
 
-      <section className="mt-4 rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-3">
-        <button
-          className="flex w-full items-center gap-2 text-left text-sm text-[color:var(--muted-strong)]"
+      <section className="mt-4 space-y-3">
+        <Button
+          aria-expanded={isComposerExpanded}
           onClick={handleExpandComposer}
-          type="button"
+          size="sm"
+          variant={isComposerExpanded ? "subtle" : "ghost"}
         >
           <Plus className="size-4" />
           Add task
-        </button>
+        </Button>
 
         {isComposerExpanded ? (
-          <div className="mt-3 grid gap-3">
-            <Input
-              autoFocus
-              onChange={(event) => onSetNewTaskTitle(event.target.value)}
-              placeholder="Task title"
-              value={newTaskTitle}
-            />
-            <Select
-              onValueChange={(value) => onSetNewTaskProject(value === "_inbox" ? "" : value)}
-              value={newTaskProject || "_inbox"}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder={inboxPickerLabel} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="_inbox">{inboxPickerLabel}</SelectItem>
-                {visibleProjects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Input
-              onChange={(event) => onSetNewTaskTags(event.target.value)}
-              placeholder="Tags (optional, comma-separated)"
-              value={newTaskTags}
-            />
-            <Textarea
-              onChange={(event) => onSetNewTaskDetails(event.target.value)}
-              placeholder="Optional task details"
-              value={newTaskDetails}
-            />
-            <div className="flex justify-end gap-2">
-              <Button onClick={handleCollapseComposer} variant="ghost">
-                Cancel
-              </Button>
-              <Button disabled={!newTaskTitle.trim()} onClick={handleAddTaskAndCollapse}>
-                <Plus className="size-4" />
-                Add
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <p className="mt-2 text-xs text-[color:var(--muted)]">
-            Click to open the full task composer.
-          </p>
-        )}
+          <TaskEditorFields
+            allTags={allTags}
+            details={newTaskDetails}
+            isSubmitDisabled={!newTaskTitle.trim()}
+            onCancel={handleCollapseComposer}
+            onDetailsChange={onSetNewTaskDetails}
+            onProjectChange={onSetNewTaskProject}
+            onSubmit={handleAddTaskAndCollapse}
+            onTagsChange={onSetNewTaskTags}
+            onTitleChange={onSetNewTaskTitle}
+            projectId={newTaskProject}
+            projects={visibleProjects}
+            submitHint="⌘↵"
+            submitLabel="Add task"
+            tags={newTaskTags}
+            title={newTaskTitle}
+          />
+        ) : null}
       </section>
 
       <section className="mt-6">

--- a/src/features/workspace/tasks/inbox-task-composer.test.tsx
+++ b/src/features/workspace/tasks/inbox-task-composer.test.tsx
@@ -83,8 +83,8 @@ describe("inbox task composer", () => {
   });
 
   /**
-   * Confirms the expanded composer uses the new inline tags, no-chrome details area, and keyboard
-   * submit hint instead of the old full-form controls.
+   * Confirms the expanded composer uses the shared labeled task form, popover-backed tag picker,
+   * and explicit footer actions instead of the old ad hoc controls.
    */
   it("renders the redesigned expanded composer block", () => {
     const markup = renderToStaticMarkup(
@@ -99,9 +99,10 @@ describe("inbox task composer", () => {
     expect(markup).toContain("Task title");
     expect(markup).toContain("Add tag");
     expect(markup).toContain("⌘↵");
+    expect(markup).toContain("Cancel");
+    expect(markup).toContain("Add task");
     expect(markup).toContain('aria-label="Remove planning tag"');
     expect(markup).toContain('data-slot="select-trigger"');
     expect(markup).not.toContain("Tags (optional, comma-separated)");
-    expect(markup).not.toContain(">Cancel<");
   });
 });

--- a/src/features/workspace/tasks/inbox-task-composer.tsx
+++ b/src/features/workspace/tasks/inbox-task-composer.tsx
@@ -25,7 +25,7 @@ interface InboxTaskComposerProps {
 }
 
 /**
- * Renders the inbox-specific lightweight composer and keeps its tag autocomplete UI self-contained.
+ * Renders the inbox-specific task composer while reusing the shared shadcn task form.
  */
 export function InboxTaskComposer({
   allTags,
@@ -45,7 +45,7 @@ export function InboxTaskComposer({
   projects,
 }: InboxTaskComposerProps) {
   /**
-   * Collapses the composer only after inner controls like the tag combobox have had a chance to
+   * Collapses the composer only after inner controls like the tag popover have had a chance to
    * consume Escape for themselves.
    */
   function handleComposerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
@@ -76,6 +76,7 @@ export function InboxTaskComposer({
       details={newTaskDetails}
       focusTitleInputSignal={focusTitleInputSignal}
       isSubmitDisabled={!newTaskTitle.trim()}
+      onCancel={onCollapse}
       onDetailsChange={onSetNewTaskDetails}
       onKeyDown={handleComposerKeyDown}
       onProjectChange={onSetNewTaskProject}
@@ -85,6 +86,7 @@ export function InboxTaskComposer({
       projectId={newTaskProject}
       projects={projects}
       submitHint="⌘↵"
+      submitLabel="Add task"
       tags={newTaskTags}
       title={newTaskTitle}
     />

--- a/src/features/workspace/tasks/task-editor-fields.tsx
+++ b/src/features/workspace/tasks/task-editor-fields.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { type ChangeEvent, type KeyboardEvent, useCallback, useEffect, useRef } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { type Project } from "@/features/workspace/core";
 import { inboxPickerLabel, readProjectPickerValue } from "@/features/workspace/projects";
-import { cn } from "@/lib/utils";
 
 import {
   formatTaskTagString,
@@ -35,7 +38,8 @@ interface TaskEditorFieldsProps {
 }
 
 /**
- * Reuses the issue-24 no-chrome task input language for any task create or edit surface.
+ * Provides one shared labeled task form so create and edit flows all speak the same shadcn-first
+ * design language.
  */
 export function TaskEditorFields({
   allTags,
@@ -56,31 +60,19 @@ export function TaskEditorFields({
   tags,
   title,
 }: TaskEditorFieldsProps) {
-  const titleInputRef = useRef<HTMLTextAreaElement>(null);
+  const titleInputId = useId();
+  const detailsInputId = useId();
+  const projectTriggerId = useId();
+  const titleInputRef = useRef<HTMLInputElement>(null);
   const selectedTags = parseTaskTagString(tags);
-
-  /**
-   * Auto-sizes the title textarea to its content so it grows with long titles but never shows
-   * a scrollbar.
-   */
-  const resizeTitleTextarea = useCallback(() => {
-    const element = titleInputRef.current;
-
-    if (!element) {
-      return;
-    }
-
-    element.style.height = "auto";
-    element.style.height = `${element.scrollHeight}px`;
-  }, []);
+  const hasFooter = Boolean(submitHint || onCancel || (submitLabel && onSubmit));
 
   /**
    * Focuses the title input on open and on later explicit refocus requests like Cmd+N.
    */
   useEffect(() => {
     titleInputRef.current?.focus();
-    resizeTitleTextarea();
-  }, [focusTitleInputSignal, resizeTitleTextarea]);
+  }, [focusTitleInputSignal]);
 
   /**
    * Preserves the shared Cmd/Ctrl+Enter submit gesture while still allowing parent-specific
@@ -102,27 +94,23 @@ export function TaskEditorFields({
 
   return (
     <div
-      className="rounded-md border border-[color:var(--border)] bg-[color:var(--surface)]/90 px-3 py-1.5"
+      className="rounded-md border border-[color:var(--border)] bg-[color:var(--surface)] p-4"
       onKeyDown={handleKeyDown}
     >
-      <div className="flex items-start gap-3">
-        <textarea
-          aria-label="Task title"
-          className={cn(
-            "min-w-0 basis-3/4 resize-none overflow-hidden border-0 border-b border-[color:var(--border)] bg-transparent px-0 pb-2 pt-0 text-sm text-[color:var(--foreground)] shadow-none outline-none transition-colors",
-            "placeholder:text-[color:var(--muted)] placeholder:opacity-70 focus:border-[color:var(--border-strong)]",
-          )}
-          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
-            onTitleChange(event.target.value.replace(/\n/g, " "));
-            resizeTitleTextarea();
-          }}
-          placeholder="Task title"
-          ref={titleInputRef}
-          rows={1}
-          value={title}
-        />
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(15rem,1fr)]">
+        <div className="space-y-2">
+          <Label htmlFor={titleInputId}>Task title</Label>
+          <Input
+            id={titleInputId}
+            onChange={(event) => onTitleChange(event.target.value)}
+            placeholder="What needs to happen?"
+            ref={titleInputRef}
+            value={title}
+          />
+        </div>
 
-        <div className="basis-1/4">
+        <div className="space-y-2">
+          <Label>Tags</Label>
           <TaskTagCombobox
             allTags={allTags}
             onChange={(nextTags) => onTagsChange(formatTaskTagString(nextTags))}
@@ -131,23 +119,23 @@ export function TaskEditorFields({
         </div>
       </div>
 
-      <Textarea
-        aria-label="Task details"
-        className="mt-2 min-h-20 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[12px] leading-5 focus-visible:border-0 focus-visible:bg-transparent focus-visible:ring-0"
-        onChange={(event) => onDetailsChange(event.target.value)}
-        placeholder="Add details..."
-        value={details}
-      />
+      <div className="mt-4 space-y-2">
+        <Label htmlFor={detailsInputId}>Details</Label>
+        <Textarea
+          id={detailsInputId}
+          onChange={(event) => onDetailsChange(event.target.value)}
+          placeholder="Add details..."
+          value={details}
+        />
+      </div>
 
-      <div className="mt-2 flex flex-wrap items-center justify-between gap-4">
+      <div className="mt-4 space-y-2">
+        <Label htmlFor={projectTriggerId}>Project</Label>
         <Select
           onValueChange={(value) => onProjectChange(value === "_inbox" ? "" : value)}
           value={readProjectPickerValue(projectId) || "_inbox"}
         >
-          <SelectTrigger
-            aria-label="Project"
-            className="h-8 w-auto min-w-[11rem] rounded-none border-0 bg-transparent px-0 py-0 text-xs text-[color:var(--muted)] focus:bg-transparent focus:ring-0"
-          >
+          <SelectTrigger aria-label="Project" id={projectTriggerId}>
             <SelectValue placeholder={inboxPickerLabel} />
           </SelectTrigger>
           <SelectContent>
@@ -159,32 +147,29 @@ export function TaskEditorFields({
             ))}
           </SelectContent>
         </Select>
-
-        <div className="flex items-center gap-3">
-          {submitHint ? (
-            <span className="text-[11px] text-[color:var(--muted)]">{submitHint}</span>
-          ) : null}
-          {onCancel ? (
-            <button
-              className="text-[11px] text-[color:var(--muted)] transition-colors hover:text-[color:var(--foreground)]"
-              onClick={onCancel}
-              type="button"
-            >
-              Cancel
-            </button>
-          ) : null}
-          {submitLabel && onSubmit ? (
-            <button
-              className="text-[11px] font-medium text-[color:var(--foreground)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
-              disabled={isSubmitDisabled}
-              onClick={onSubmit}
-              type="button"
-            >
-              {submitLabel}
-            </button>
-          ) : null}
-        </div>
       </div>
+
+      {hasFooter ? (
+        <div className="mt-4 space-y-3">
+          <Separator />
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-xs text-[color:var(--muted)]">{submitHint ?? ""}</div>
+
+            <div className="flex items-center gap-2">
+              {onCancel ? (
+                <Button onClick={onCancel} size="sm" variant="ghost">
+                  Cancel
+                </Button>
+              ) : null}
+              {submitLabel && onSubmit ? (
+                <Button disabled={isSubmitDisabled} onClick={onSubmit} size="sm">
+                  {submitLabel}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/features/workspace/tasks/task-inline-editor.test.tsx
+++ b/src/features/workspace/tasks/task-inline-editor.test.tsx
@@ -2,6 +2,7 @@ import { Children, isValidElement, type ReactElement, type ReactNode } from "rea
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { Button } from "@/components/ui/button";
 import { workspaceSeed } from "@/features/workspace/mock-data";
 import { filterVisibleProjects } from "@/features/workspace/projects";
 
@@ -95,7 +96,7 @@ describe("task inline editor", () => {
     const deleteButton = findElement(
       tree,
       (element) =>
-        element.type === "button" &&
+        element.type === Button &&
         Children.toArray(element.props.children).join("").includes("Delete"),
     ) as ReactElement<{ onClick?: () => void }> | null;
 

--- a/src/features/workspace/tasks/task-inline-editor.tsx
+++ b/src/features/workspace/tasks/task-inline-editor.tsx
@@ -2,6 +2,7 @@
 
 import { type KeyboardEvent } from "react";
 
+import { Button } from "@/components/ui/button";
 import { type Project, type Task } from "@/features/workspace/core";
 
 import { TaskEditorFields } from "./task-editor-fields";
@@ -77,13 +78,15 @@ export function TaskInlineEditor({
       />
 
       <div className="flex justify-end">
-        <button
-          className="text-[11px] text-rose-600 transition-colors hover:text-rose-700"
+        <Button
+          className="text-rose-600 hover:bg-rose-50 hover:text-rose-700"
           onClick={() => onDelete(task.id)}
+          size="sm"
           type="button"
+          variant="ghost"
         >
           Delete
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/features/workspace/tasks/task-tag-combobox.tsx
+++ b/src/features/workspace/tasks/task-tag-combobox.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { type KeyboardEvent, useId, useRef, useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 
-import { X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { type Task } from "@/features/workspace/core";
 import { cn } from "@/lib/utils";
 
@@ -14,8 +17,8 @@ interface TaskTagComboboxProps {
 }
 
 /**
- * Keeps task tag editing lightweight by combining selected pills, free-text entry, and workspace
- * suggestions into one compact inline control.
+ * Uses a stock popover-plus-input composition so task tags behave like the rest of the shadcn
+ * form controls while still supporting quick add and remove flows.
  */
 export function TaskTagCombobox({
   allTags,
@@ -23,37 +26,36 @@ export function TaskTagCombobox({
   onChange,
 }: TaskTagComboboxProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const listboxId = useId();
   const [tagQuery, setTagQuery] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const suggestions = readTaskTagSuggestions(allTags, tagQuery, selectedTags);
-  const highlightedSuggestionIndex =
-    suggestions.length === 0
-      ? 0
-      : Math.min(activeSuggestionIndex, suggestions.length - 1);
-  const isShowingDropdown = isDropdownOpen && suggestions.length > 0;
+  const normalizedQuery = normalizeTaskTag(tagQuery);
+  const hasExistingExactMatch = allTags.some(
+    (tag) => normalizeTaskTag(tag).toLocaleLowerCase() === normalizedQuery.toLocaleLowerCase(),
+  );
+  const isSelectedExactMatch = selectedTags.some(
+    (tag) => normalizeTaskTag(tag).toLocaleLowerCase() === normalizedQuery.toLocaleLowerCase(),
+  );
+  const canCreateTag =
+    normalizedQuery.length > 0 && !hasExistingExactMatch && !isSelectedExactMatch;
 
   /**
-   * Adds the confirmed tag, clears the current query, and keeps focus inside the inline editor.
+   * Adds a confirmed tag, clears the current search state, and keeps focus in the popover search.
    */
   function handleConfirmTag(nextTag: string) {
     const normalizedTag = normalizeTaskTag(nextTag);
 
     if (!normalizedTag) {
-      setIsDropdownOpen(false);
       return;
     }
 
     onChange(appendTaskTag(selectedTags, normalizedTag));
     setTagQuery("");
-    setIsDropdownOpen(false);
-    setActiveSuggestionIndex(0);
     inputRef.current?.focus();
   }
 
   /**
-   * Removes one selected tag while preserving the rest of the draft state.
+   * Removes a tag from the current draft without changing the surrounding editor state.
    */
   function handleRemoveTag(tagToRemove: string) {
     onChange(
@@ -61,83 +63,43 @@ export function TaskTagCombobox({
         (tag) => tag.toLocaleLowerCase() !== tagToRemove.toLocaleLowerCase(),
       ),
     );
-    inputRef.current?.focus();
   }
 
   /**
-   * Handles keyboard selection so Enter and comma confirm tags while Escape closes only the
-   * dropdown first.
+   * Keeps Enter and comma scoped to tag creation so the parent task editor does not submit early.
    */
-  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === "ArrowDown") {
-      if (suggestions.length === 0) {
+  function handleSearchKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" || event.key === ",") {
+      if (!normalizedQuery) {
         return;
       }
 
       event.preventDefault();
       event.stopPropagation();
-      setIsDropdownOpen(true);
-      setActiveSuggestionIndex((currentIndex) =>
-        currentIndex >= suggestions.length - 1 ? 0 : currentIndex + 1,
-      );
+      handleConfirmTag(suggestions[0] ?? normalizedQuery);
       return;
     }
 
-    if (event.key === "ArrowUp") {
-      if (suggestions.length === 0) {
-        return;
-      }
-
-      event.preventDefault();
+    if (event.key === "Escape") {
       event.stopPropagation();
-      setIsDropdownOpen(true);
-      setActiveSuggestionIndex((currentIndex) =>
-        currentIndex <= 0 ? suggestions.length - 1 : currentIndex - 1,
-      );
-      return;
-    }
-
-    if (event.key === "Enter") {
-      if (!tagQuery.trim()) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      handleConfirmTag(
-        isShowingDropdown
-          ? (suggestions[highlightedSuggestionIndex] ?? tagQuery)
-          : tagQuery,
-      );
-      return;
-    }
-
-    if (event.key === ",") {
-      if (!tagQuery.trim()) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      handleConfirmTag(tagQuery);
-      return;
-    }
-
-    if (event.key === "Escape" && isDropdownOpen) {
-      event.preventDefault();
-      event.stopPropagation();
-      setIsDropdownOpen(false);
-      setActiveSuggestionIndex(0);
+      setIsPopoverOpen(false);
     }
   }
 
   return (
-    <div className="relative min-w-[11rem] flex-1">
-      <div className="flex flex-wrap items-center justify-end gap-1.5">
+    <div className="space-y-2">
+      <div className="flex min-h-10 flex-wrap items-center gap-2 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-3 py-2">
+        {selectedTags.length === 0 ? (
+          <span className="text-sm text-[color:var(--muted)]">No tags selected</span>
+        ) : null}
+
         {selectedTags.map((tag) => (
           <button
             aria-label={`Remove ${tag} tag`}
-            className="inline-flex items-center gap-1 rounded-full bg-[color:var(--surface-muted)] px-2 py-0.5 text-[11px] text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-strong)] hover:text-[color:var(--foreground)]"
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-2.5 py-1 text-xs text-[color:var(--muted-strong)] transition-colors",
+              "hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]",
+            )}
             key={tag}
             onClick={() => handleRemoveTag(tag)}
             type="button"
@@ -147,70 +109,99 @@ export function TaskTagCombobox({
           </button>
         ))}
 
-        <input
-          aria-activedescendant={
-            isShowingDropdown ? `${listboxId}-${highlightedSuggestionIndex}` : undefined
-          }
-          aria-controls={isShowingDropdown ? listboxId : undefined}
-          aria-expanded={isShowingDropdown}
-          aria-label="Task tags"
-          aria-autocomplete="list"
-          className="h-6 min-w-[5rem] flex-1 bg-transparent px-0 text-right text-[11px] text-[color:var(--muted)] outline-none placeholder:text-[color:var(--muted)] placeholder:opacity-70 focus:text-[color:var(--foreground)]"
-          onBlur={() => setIsDropdownOpen(false)}
-          onChange={(event) => {
-            setTagQuery(event.target.value);
-            setIsDropdownOpen(true);
-            setActiveSuggestionIndex(0);
-          }}
-          onFocus={() => {
-            if (suggestions.length > 0) {
-              setIsDropdownOpen(true);
+        <Popover
+          onOpenChange={(nextOpen) => {
+            setIsPopoverOpen(nextOpen);
+
+            if (!nextOpen) {
+              setTagQuery("");
             }
           }}
-          onKeyDown={handleInputKeyDown}
-          placeholder="Add tag"
-          ref={inputRef}
-          role="combobox"
-          value={tagQuery}
-        />
-      </div>
-
-      {isShowingDropdown ? (
-        <div
-          className="absolute right-0 top-full z-10 mt-2 min-w-[11rem] overflow-hidden rounded-md border border-[color:var(--border)] bg-[color:var(--popover)]"
-          id={listboxId}
-          role="listbox"
+          open={isPopoverOpen}
         >
-          <ul className="max-h-36 overflow-y-auto py-1">
-            {suggestions.map((tag, index) => {
-              const isActive = index === highlightedSuggestionIndex;
+          <PopoverTrigger asChild>
+            <Button
+              aria-label="Add tag"
+              className="ml-auto h-7 px-2 text-xs"
+              size="sm"
+              variant="ghost"
+            >
+              Add tag
+            </Button>
+          </PopoverTrigger>
 
-              return (
-                <li key={tag}>
-                  <button
-                    aria-selected={isActive}
-                    className={cn(
-                      "w-full px-3 py-1.5 text-left text-xs transition-colors",
-                      isActive
-                        ? "bg-[color:var(--surface-muted)] text-[color:var(--foreground)]"
-                        : "text-[color:var(--muted)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]",
-                    )}
-                    id={`${listboxId}-${index}`}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      handleConfirmTag(tag);
-                    }}
-                    role="option"
-                    type="button"
-                  >
-                    {tag}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ) : null}
+          <PopoverContent
+            align="end"
+            className="w-80 space-y-3"
+            onEscapeKeyDown={(event) => {
+              event.stopPropagation();
+            }}
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              inputRef.current?.focus();
+            }}
+          >
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-[color:var(--popover-foreground)]">
+                Choose tags
+              </p>
+              <p className="text-xs text-[color:var(--muted)]">
+                Search existing tags or create a new one.
+              </p>
+            </div>
+
+            <Input
+              aria-label="Tag search"
+              onChange={(event) => setTagQuery(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              placeholder="Search or create tags"
+              ref={inputRef}
+              value={tagQuery}
+            />
+
+            <div className="space-y-1.5">
+              {canCreateTag ? (
+                <button
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                    "text-[color:var(--popover-foreground)] hover:bg-[color:var(--surface-muted)]",
+                  )}
+                  onClick={() => handleConfirmTag(normalizedQuery)}
+                  type="button"
+                >
+                  <Plus aria-hidden="true" className="size-4 text-[color:var(--muted)]" />
+                  <span>
+                    Create &quot;
+                    {normalizedQuery}
+                    &quot;
+                  </span>
+                </button>
+              ) : null}
+
+              {suggestions.map((tag) => (
+                <button
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                    "text-[color:var(--popover-foreground)] hover:bg-[color:var(--surface-muted)]",
+                  )}
+                  key={tag}
+                  onClick={() => handleConfirmTag(tag)}
+                  type="button"
+                >
+                  <Plus aria-hidden="true" className="size-4 text-[color:var(--muted)]" />
+                  <span>{tag}</span>
+                </button>
+              ))}
+
+              {suggestions.length === 0 && !canCreateTag ? (
+                <p className="rounded-md border border-dashed border-[color:var(--border)] px-3 py-2 text-sm text-[color:var(--muted)]">
+                  No matching tags yet.
+                </p>
+              ) : null}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
     </div>
   );
 }
@@ -246,7 +237,7 @@ export function collectTaskTags(tasks: Pick<Task, "tags">[]) {
 
 /**
  * Filters autocomplete suggestions using a case-insensitive substring match and selected-tag
- * exclusion so the inline picker never offers duplicates back to the user.
+ * exclusion so the tag picker never offers duplicates back to the user.
  */
 export function readTaskTagSuggestions(
   allTags: string[],
@@ -276,7 +267,7 @@ export function readTaskTagSuggestions(
 
 /**
  * Converts the existing comma-separated task tag storage format into the array form used by the
- * inline combobox UI.
+ * shared task editor.
  */
 export function parseTaskTagString(tags: string) {
   return tags

--- a/src/features/workspace/theme/workspace-theme-selector.tsx
+++ b/src/features/workspace/theme/workspace-theme-selector.tsx
@@ -1,12 +1,20 @@
 "use client";
 
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 import {
   readWorkspaceThemeFlag,
   readWorkspaceThemeLabel,
   type WorkspaceThemeMode,
-  type WorkspaceThemePalette,
   type WorkspaceThemeSelection,
   workspaceThemeFlags,
 } from "./workspace-theme";
@@ -28,15 +36,9 @@ export function WorkspaceThemeSelector({
   const activeThemeFlag = readWorkspaceThemeFlag(selection.themeId);
 
   return (
-    <section
-      aria-label="Theme options"
-      className={cn(
-        "workspace-theme-panel rounded-[28px] border border-[color:var(--border)] px-4 py-4 sm:px-5 sm:py-5",
-        !showHeader && "border-none bg-transparent px-0 py-0 shadow-none backdrop-blur-none",
-      )}
-    >
+    <section aria-label="Theme options" className="space-y-4">
       {showHeader ? (
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
           <div className="max-w-3xl">
             <p className="text-xs font-medium uppercase tracking-[0.22em] text-[color:var(--muted)]">
               Theme Options
@@ -50,79 +52,111 @@ export function WorkspaceThemeSelector({
             </p>
           </div>
 
-          <div className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface-strong)] px-4 py-3 shadow-[0_16px_40px_-28px_var(--shadow-color)]">
-            <p className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--muted)]">
-              Current Theme
-            </p>
-            <p className="mt-2 text-sm font-medium text-[color:var(--foreground)]">
-              {readWorkspaceThemeLabel(selection)}
-            </p>
-            <p className="mt-1 text-xs text-[color:var(--muted)]">{activeThemeFlag.summary}</p>
-          </div>
+          <CurrentThemeCard
+            activeThemeFlag={activeThemeFlag}
+            selection={selection}
+          />
         </div>
       ) : null}
 
-      <div className={cn("grid gap-3 xl:grid-cols-3 md:grid-cols-2", showHeader && "mt-5")}>
-        {workspaceThemeFlags.map((themeFlag, index) => {
+      <div className={cn("grid gap-3 md:grid-cols-2 xl:grid-cols-3", showHeader && "pt-1")}>
+        {workspaceThemeFlags.map((themeFlag) => {
           const isActiveTheme = selection.themeId === themeFlag.id;
 
           return (
-            <article
-              className={cn(
-                "rounded-[24px] border px-4 py-4 transition-all duration-200",
-                isActiveTheme
-                  ? "border-[color:var(--border-strong)] bg-[color:var(--surface)] shadow-[0_24px_50px_-32px_var(--shadow-color)]"
-                  : "border-[color:var(--border)] bg-[color:var(--surface-strong)]",
-              )}
+            <ThemeOptionCard
+              isActiveTheme={isActiveTheme}
               key={themeFlag.id}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--muted)]">
-                    Option {String(index + 1).padStart(2, "0")}
-                  </p>
-                  <h3 className="mt-2 text-sm font-semibold text-[color:var(--foreground)]">
-                    {themeFlag.name}
-                  </h3>
-                </div>
-
-                {isActiveTheme ? (
-                  <span className="rounded-full bg-[color:var(--surface-muted)] px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted-strong)]">
-                    Active
-                  </span>
-                ) : null}
-              </div>
-
-              <p className="mt-3 min-h-[4.5rem] text-sm leading-6 text-[color:var(--muted)]">
-                {themeFlag.summary}
-              </p>
-
-              <div className="mt-4 grid grid-cols-2 gap-2">
-                <ThemeModeButton
-                  isActive={isActiveTheme && selection.mode === "day"}
-                  label="Day"
-                  mode="day"
-                  onSelectTheme={onSelectTheme}
-                  themeId={themeFlag.id}
-                />
-                <ThemeModeButton
-                  isActive={isActiveTheme && selection.mode === "night"}
-                  label="Night"
-                  mode="night"
-                  onSelectTheme={onSelectTheme}
-                  themeId={themeFlag.id}
-                />
-              </div>
-
-              <div className="mt-4 grid grid-cols-2 gap-2">
-                <ThemePalettePreview label="Day" palette={themeFlag.day} />
-                <ThemePalettePreview label="Night" palette={themeFlag.night} />
-              </div>
-            </article>
+              onSelectTheme={onSelectTheme}
+              selection={selection}
+              themeFlag={themeFlag}
+            />
           );
         })}
       </div>
     </section>
+  );
+}
+
+interface CurrentThemeCardProps {
+  activeThemeFlag: ReturnType<typeof readWorkspaceThemeFlag>;
+  selection: WorkspaceThemeSelection;
+}
+
+/**
+ * Keeps the active theme visible without depending on the larger custom showcase panel.
+ */
+function CurrentThemeCard({ activeThemeFlag, selection }: CurrentThemeCardProps) {
+  return (
+    <Card className="bg-[color:var(--surface-strong)] shadow-none">
+      <CardHeader className="gap-2 p-4">
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--muted)]">
+          Current Theme
+        </p>
+        <CardTitle>{readWorkspaceThemeLabel(selection)}</CardTitle>
+        <CardDescription>{activeThemeFlag.summary}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+interface ThemeOptionCardProps {
+  isActiveTheme: boolean;
+  onSelectTheme: (selection: WorkspaceThemeSelection) => void;
+  selection: WorkspaceThemeSelection;
+  themeFlag: typeof workspaceThemeFlags[number];
+}
+
+/**
+ * Uses a stock card layout so each theme reads as a simple selectable option instead of a custom
+ * preview block.
+ */
+function ThemeOptionCard({
+  isActiveTheme,
+  onSelectTheme,
+  selection,
+  themeFlag,
+}: ThemeOptionCardProps) {
+  return (
+    <Card
+      className={cn(
+        "h-full bg-[color:var(--surface-strong)] shadow-none transition-colors",
+        isActiveTheme && "border-[color:var(--border-strong)] bg-[color:var(--surface)]",
+      )}
+    >
+      <CardHeader className="gap-3 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <CardTitle className="min-w-0">{themeFlag.name}</CardTitle>
+
+          {isActiveTheme ? <Badge variant="secondary">Active</Badge> : null}
+        </div>
+
+        <CardDescription>{themeFlag.summary}</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-3 px-4 pb-4 pt-0">
+        <div className="flex flex-wrap gap-2">
+          <ThemeModeButton
+            isActive={isActiveTheme && selection.mode === "day"}
+            label="Day"
+            mode="day"
+            onSelectTheme={onSelectTheme}
+            themeId={themeFlag.id}
+          />
+          <ThemeModeButton
+            isActive={isActiveTheme && selection.mode === "night"}
+            label="Night"
+            mode="night"
+            onSelectTheme={onSelectTheme}
+            themeId={themeFlag.id}
+          />
+        </div>
+
+        <p className="text-xs leading-5 text-[color:var(--muted)]">
+          {readThemeSupportText(isActiveTheme, selection.mode)}
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -145,80 +179,31 @@ function ThemeModeButton({
   onSelectTheme,
 }: ThemeModeButtonProps) {
   return (
-    <button
+    <Button
       aria-label={`${readWorkspaceThemeFlag(themeId).name} ${label.toLowerCase()} theme`}
       aria-pressed={isActive}
-      className={cn(
-        "cursor-pointer rounded-2xl border px-3 py-2 text-sm font-medium transition-all duration-150",
-        isActive
-          ? "border-[color:var(--border-strong)] bg-[color:var(--accent)] text-[color:var(--accent-foreground)] shadow-[0_16px_32px_-22px_var(--shadow-color)]"
-          : "border-[color:var(--border)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface)]",
-      )}
+      className="min-w-20"
       onClick={() =>
         onSelectTheme({
           themeId,
           mode,
         })
       }
-      type="button"
+      size="sm"
+      variant={isActive ? "default" : "outline"}
     >
       {label}
-    </button>
+    </Button>
   );
-}
-
-interface ThemePalettePreviewProps {
-  label: string;
-  palette: WorkspaceThemePalette;
 }
 
 /**
- * Shows a compact visual swatch so unselected theme options can still be compared at a glance.
+ * Keeps the helper copy short while still confirming the currently selected mode when relevant.
  */
-function ThemePalettePreview({ label, palette }: ThemePalettePreviewProps) {
-  return (
-    <div
-      className="rounded-[18px] border p-2"
-      style={{
-        background: palette.surface,
-        borderColor: palette.border,
-        boxShadow: `0 10px 26px -24px ${palette.shadowColor}`,
-      }}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <span
-          className="text-xs font-semibold uppercase tracking-[0.16em]"
-          style={{ color: palette.muted }}
-        >
-          {label}
-        </span>
-        <span
-          className="text-xs font-medium uppercase tracking-[0.12em]"
-          style={{ color: palette.mutedStrong }}
-        >
-          {label === "Day" ? "Sun" : "Moon"}
-        </span>
-      </div>
+function readThemeSupportText(isActiveTheme: boolean, mode: WorkspaceThemeMode) {
+  if (isActiveTheme) {
+    return `Currently using the ${mode} pair for this workspace palette.`;
+  }
 
-      <div className="mt-2 grid grid-cols-[1.2fr_1fr] gap-2">
-        <div
-          className="h-9 rounded-xl"
-          style={{
-            background: `linear-gradient(135deg, ${palette.accent}, ${palette.surfaceMuted})`,
-          }}
-        />
-
-        <div className="space-y-1">
-          <div className="h-4 rounded-lg" style={{ background: palette.background }} />
-          <div
-            className="h-4 rounded-lg border"
-            style={{
-              background: palette.surfaceStrong,
-              borderColor: palette.border,
-            }}
-          />
-        </div>
-      </div>
-    </div>
-  );
+  return "Choose Day or Night to switch the workspace onto this palette.";
 }

--- a/src/features/workspace/threads/agent-thread-panel.tsx
+++ b/src/features/workspace/threads/agent-thread-panel.tsx
@@ -2,8 +2,16 @@
 
 import { Bot, Send, Trash2, User } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { type AgentThread, type ThreadDraft } from "@/features/workspace/core";
 import { getProviderLabel } from "@/features/workspace/providers";
@@ -39,16 +47,18 @@ export function AgentThreadPanel({
   onDeleteMessage,
 }: AgentThreadPanelProps) {
   return (
-    <section className="space-y-3 pt-3">
-      <Separator />
-      <p className="text-xs uppercase tracking-[0.14em] text-[color:var(--muted)]">
-        {readThreadActivityLabel(thread.messages.length)}
-      </p>
+    <div className="space-y-4 pt-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge variant="secondary">{readThreadActivityLabel(thread.messages.length)}</Badge>
+        <p className="text-sm text-[color:var(--muted)]">
+          Keep agent context nearby without adding another bespoke panel.
+        </p>
+      </div>
 
       {thread.messages.length > 0 ? (
         <div className="space-y-3">
           {thread.messages.map((message) => (
-            <ThreadMessageRow
+            <ThreadMessageCard
               key={message.id}
               message={message}
               onDelete={() => onDeleteMessage(message.id)}
@@ -56,81 +66,95 @@ export function AgentThreadPanel({
           ))}
         </div>
       ) : (
-        <p className="text-sm text-[color:var(--muted)]">{emptyStateLabel}</p>
+        <Card className="border-dashed">
+          <CardContent className="flex min-h-24 items-center justify-center px-6 py-6 text-center text-sm text-[color:var(--muted)]">
+            {emptyStateLabel}
+          </CardContent>
+        </Card>
       )}
 
-      <div className="space-y-3">
-        <p className="text-sm text-[color:var(--muted)]">
-          Using {activeProviderLabel} · {activeProviderModel}
-        </p>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Continue thread</CardTitle>
+          <CardDescription>
+            {`Using ${activeProviderLabel} · ${activeProviderModel}`}
+          </CardDescription>
+        </CardHeader>
 
-        <Textarea
-          onChange={(event) => onDraftChange(event.target.value)}
-          placeholder={composerPlaceholder}
-          value={draft.message}
-        />
+        <CardContent className="space-y-3">
+          <Textarea
+            onChange={(event) => onDraftChange(event.target.value)}
+            placeholder={composerPlaceholder}
+            value={draft.message}
+          />
 
-        {draft.error ? <p className="text-sm text-rose-700">{draft.error}</p> : null}
+          {draft.error ? <p className="text-sm text-rose-700">{draft.error}</p> : null}
+        </CardContent>
 
-        <div className="flex justify-end">
+        <CardFooter className="justify-end">
           <Button disabled={isPending} onClick={onSend} size="sm">
             <Send className="size-4" />
             {isPending ? "Sending..." : "Send"}
           </Button>
-        </div>
-      </div>
-    </section>
+        </CardFooter>
+      </Card>
+    </div>
   );
 }
 
-interface ThreadMessageRowProps {
+interface ThreadMessageCardProps {
   message: AgentThread["messages"][number];
   onDelete: () => void;
 }
 
 /**
- * Keeps one thread message readable while visually separating human and agent turns.
+ * Keeps one thread message readable while moving the visual structure onto shared card sections.
  */
-function ThreadMessageRow({ message, onDelete }: ThreadMessageRowProps) {
+function ThreadMessageCard({ message, onDelete }: ThreadMessageCardProps) {
   const isAgentMessage = message.role === "agent";
   const providerLabel = isAgentMessage && message.providerId ? getProviderLabel(message.providerId) : null;
 
   return (
-    <div
-      className={
-        isAgentMessage
-          ? "rounded-md border border-[color:var(--row-divider)] bg-[color:var(--surface)] p-3"
-          : "rounded-md border border-[color:var(--row-divider)] bg-[color:var(--background)] p-3"
-      }
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="flex items-center gap-2 text-sm font-medium">
+    <Card className={isAgentMessage ? "bg-[color:var(--surface-muted)]" : "bg-[color:var(--background)]"}>
+      <CardHeader className="gap-3 pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle className="flex items-center gap-2 text-base">
             {isAgentMessage ? <Bot className="size-4" /> : <User className="size-4" />}
             {isAgentMessage ? "Agent" : "You"}
-            {providerLabel ? <span className="font-normal text-[color:var(--muted)]">{providerLabel}</span> : null}
-            {isAgentMessage && message.status ? (
-              <span className="font-normal text-[color:var(--muted)]">· {message.status}</span>
-            ) : null}
-          </p>
-          <p className="text-xs text-[color:var(--muted)]">{message.createdAt}</p>
-
-          {isAgentMessage ? (
-            <FormattedAgentResponse className="mt-2" content={message.content} />
-          ) : (
-            <p className="mt-2 whitespace-pre-wrap text-sm text-[color:var(--foreground)]">
-              {message.content}
-            </p>
-          )}
+          </CardTitle>
+          <CardDescription>{readThreadMessageMeta(message.createdAt, providerLabel, message.status)}</CardDescription>
         </div>
 
         <Button aria-label="Delete message" onClick={onDelete} size="sm" variant="ghost">
           <Trash2 className="size-4" />
           Delete
         </Button>
-      </div>
-    </div>
+      </CardHeader>
+
+      <CardContent>
+        {isAgentMessage ? (
+          <FormattedAgentResponse className="mt-0" content={message.content} />
+        ) : (
+          <p className="whitespace-pre-wrap text-sm text-[color:var(--foreground)]">
+            {message.content}
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
+}
+
+/**
+ * Reads the compact metadata line shown beneath each thread message title.
+ */
+function readThreadMessageMeta(
+  createdAt: string,
+  providerLabel: string | null,
+  status?: AgentThread["messages"][number]["status"],
+) {
+  const details = [providerLabel, createdAt, status].filter(Boolean);
+
+  return details.join(" · ");
 }
 
 /**

--- a/src/features/workspace/workspace-app.tsx
+++ b/src/features/workspace/workspace-app.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { featureFlags } from "@/features/feature-flags";
 import { AgentConfigurationView } from "@/features/workspace/agent-configuration-view";
@@ -150,6 +150,18 @@ export function WorkspaceApp() {
     buildGlobalSearchResults(workspace),
     globalSearchQuery,
   );
+
+  /**
+   * Clears task-detail-specific UI state without mutating the underlying task data.
+   */
+  const clearTaskFocus = useCallback(() => {
+    setSelectedTaskId(null);
+    setEditingTaskId(null);
+    setEditTitle("");
+    setEditDetails("");
+    setEditProject("");
+    setEditTags("");
+  }, []);
 
   /**
    * Hydrates saved workspace data after mount so task edits survive a browser refresh.
@@ -364,7 +376,7 @@ export function WorkspaceApp() {
     }
 
     clearTaskFocus();
-  }, [activeMenu, selectedProjectId, selectedTaskId, workspace.tasks]);
+  }, [activeMenu, clearTaskFocus, selectedProjectId, selectedTaskId, workspace.tasks]);
 
   /**
    * Resets the highlighted search row whenever the query changes so Enter always targets the
@@ -530,13 +542,6 @@ export function WorkspaceApp() {
   }
 
   /**
-   * Clears task-detail-specific UI state without mutating the underlying task data.
-   */
-  function clearTaskFocus() {
-    handleCancelEdit();
-  }
-
-  /**
    * Opens a task directly into inline edit mode by mirroring its current values into local draft
    * state.
    */
@@ -592,12 +597,7 @@ export function WorkspaceApp() {
    * Cancels row editing and clears the temporary draft values.
    */
   function handleCancelEdit() {
-    setSelectedTaskId(null);
-    setEditingTaskId(null);
-    setEditTitle("");
-    setEditDetails("");
-    setEditProject("");
-    setEditTags("");
+    clearTaskFocus();
   }
 
   /**
@@ -1117,7 +1117,7 @@ export function WorkspaceApp() {
    * the focused center-pane destination when needed.
    */
   function handleSelectGlobalSearchResult(result: GlobalSearchResult) {
-    const selection = resolveGlobalSearchSelection(result, workspace);
+    const selection = resolveGlobalSearchSelection(result);
 
     setActiveMenu(selection.activeMenu);
     setSelectedProjectId(selection.selectedProjectId);

--- a/src/features/workspace/workspace-app.tsx
+++ b/src/features/workspace/workspace-app.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Search } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { featureFlags } from "@/features/feature-flags";
 import { AgentConfigurationView } from "@/features/workspace/agent-configuration-view";
 import { ArchiveView } from "@/features/workspace/archive-view";
@@ -28,6 +30,7 @@ import {
   type WorkspaceMenu,
   WorkspaceCollapsedRail,
   WorkspaceSidebar,
+  WorkspaceTopMenu,
 } from "@/features/workspace/navigation";
 import {
   filterVisibleProjects,
@@ -102,6 +105,7 @@ export function WorkspaceApp() {
   const [hasLoadedGroupingMode, setHasLoadedGroupingMode] = useState(false);
   const [hasLoadedThemeSelection, setHasLoadedThemeSelection] = useState(false);
   const [activeMenu, setActiveMenu] = useState(createDefaultWorkspaceMenu);
+  const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false);
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const [isProjectsExpanded, setIsProjectsExpanded] = useState(true);
   const [isInitiativesExpanded, setIsInitiativesExpanded] = useState(true);
@@ -407,11 +411,21 @@ export function WorkspaceApp() {
   }
 
   /**
+   * Opens search from either the keyboard shortcut or the shell search trigger with a fresh query.
+   */
+  function handleOpenGlobalSearch() {
+    setGlobalSearchQuery("");
+    setActiveGlobalSearchIndex(0);
+    setIsGlobalSearchOpen(true);
+  }
+
+  /**
    * Switches top-level destinations and resets entity-specific detail pages when the parent row
    * itself is clicked from the sidebar.
    */
   function handleSelectMenu(nextMenu: WorkspaceMenu) {
     setActiveMenu(nextMenu);
+    setIsWorkspaceMenuOpen(false);
     setIsSidebarVisible(true);
 
     if (nextMenu === "projects") {
@@ -1122,6 +1136,7 @@ export function WorkspaceApp() {
     setActiveMenu(selection.activeMenu);
     setSelectedProjectId(selection.selectedProjectId);
     setSelectedInitiativeId(selection.selectedInitiativeId);
+    setIsWorkspaceMenuOpen(false);
     setIsSidebarVisible(true);
 
     if (selection.selectedProjectId) {
@@ -1351,7 +1366,7 @@ export function WorkspaceApp() {
 
   return (
     <main
-      className="workspace-theme-stage min-h-screen px-4 py-6 text-[color:var(--foreground)]"
+      className="min-h-screen bg-background px-4 py-6 text-[color:var(--foreground)]"
       data-theme-mode={themeSelection.mode}
       data-theme-pair={themeSelection.themeId}
       style={buildWorkspaceThemeStyle(themeSelection)}
@@ -1406,6 +1421,29 @@ export function WorkspaceApp() {
 
           <section className="min-w-0 flex-1">
             <div className="min-h-full px-1 py-2 sm:px-3">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--row-divider)] pb-4">
+                <WorkspaceTopMenu
+                  activeMenu={activeMenu}
+                  isOpen={isWorkspaceMenuOpen}
+                  onOpenChange={setIsWorkspaceMenuOpen}
+                  onSelectMenu={handleSelectMenu}
+                />
+
+                <Button
+                  aria-label="Open global search"
+                  className="gap-3"
+                  onClick={handleOpenGlobalSearch}
+                  size="sm"
+                  variant="outline"
+                >
+                  <Search className="size-4" />
+                  <span>Search</span>
+                  <span className="text-[0.7rem] tracking-[0.16em] text-[color:var(--muted)]">
+                    Ctrl/⌘ K
+                  </span>
+                </Button>
+              </div>
+
               {renderActiveCenterContent()}
             </div>
           </section>

--- a/src/features/workspace/workspace-collapsed-rail.test.tsx
+++ b/src/features/workspace/workspace-collapsed-rail.test.tsx
@@ -13,6 +13,7 @@ describe("workspace collapsed rail", () => {
     );
 
     expect(markup).toContain("workspace-collapsed-rail");
+    expect(markup).toContain('data-slot="sidebar-rail"');
     expect(markup).toContain('aria-label="Collapsed workspace sidebar"');
     expect(markup).toContain('aria-label="Expand sidebar"');
     expect(markup).toContain("w-8");

--- a/src/features/workspace/workspace-sidebar.test.tsx
+++ b/src/features/workspace/workspace-sidebar.test.tsx
@@ -30,6 +30,10 @@ describe("workspace sidebar", () => {
     );
 
     expect(markup).toContain("workspace-sidebar-shell");
+    expect(markup).toContain('data-slot="sidebar"');
+    expect(markup).toContain('data-slot="sidebar-group-label"');
+    expect(markup).toContain('data-slot="sidebar-menu-button"');
+    expect(markup).toContain('data-slot="collapsible-content"');
     expect(markup).toContain("Inbox");
     expect(markup).toContain("Projects");
     expect(markup).toContain("Configuration");
@@ -46,7 +50,6 @@ describe("workspace sidebar", () => {
     expect(markup).not.toContain(">Relay<");
     expect(markup).not.toContain(">Workspace<");
     expect(markup).not.toContain("Quiet navigation, focused work.");
-    expect(markup).toContain('class="block text-sm font-medium">Projects</span>');
     expect(markup).toContain('class="truncate text-xs font-medium">Relay MVP</span>');
     expect(markup).toContain('data-slot="tooltip-trigger"');
     expect(markup).toContain('data-slot="separator"');

--- a/src/features/workspace/workspace-theme-selector.test.tsx
+++ b/src/features/workspace/workspace-theme-selector.test.tsx
@@ -5,7 +5,7 @@ import { WorkspaceThemeSelector } from "@/features/workspace/theme";
 
 describe("workspace theme selector", () => {
   /**
-   * Verifies the selector exposes all theme options with explicit day and night toggles.
+   * Verifies the selector exposes all theme options as simpler stock card and button surfaces.
    */
   it("renders every theme option and both mode toggles", () => {
     const markup = renderToStaticMarkup(
@@ -19,15 +19,22 @@ describe("workspace theme selector", () => {
     );
 
     expect(markup).toContain("Theme Options");
+    expect(markup).toContain("Current Theme");
     expect(markup).toContain("Relay Original");
     expect(markup).toContain("Linen Ledger");
     expect(markup).toContain("Sage Study");
     expect(markup).toContain("Coastal Signal");
     expect(markup).toContain("Clay Ember");
     expect(markup).toContain("Citrus Press");
+    expect(markup.match(/data-slot="card"/g)).toHaveLength(7);
+    expect(markup.match(/data-slot="button"/g)).toHaveLength(12);
     expect(markup.match(/aria-label="[^"]+ day theme"/g)).toHaveLength(6);
     expect(markup.match(/aria-label="[^"]+ night theme"/g)).toHaveLength(6);
     expect(markup).toContain('class="text-xs font-medium uppercase tracking-[0.22em] text-[color:var(--muted)]"');
+    expect(markup).not.toContain("Option 01");
+    expect(markup).not.toContain(">Sun<");
+    expect(markup).not.toContain(">Moon<");
+    expect(markup).not.toContain("workspace-theme-panel");
     expect(markup).not.toContain("text-[11px]");
     expect(markup).not.toContain("text-[10px]");
   });

--- a/src/features/workspace/workspace-top-menu.test.tsx
+++ b/src/features/workspace/workspace-top-menu.test.tsx
@@ -11,31 +11,34 @@ describe("workspace top menu", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceTopMenu
         activeMenu="inbox"
-        isExpanded={false}
+        isOpen={false}
+        onOpenChange={vi.fn()}
         onSelectMenu={vi.fn()}
-        onToggleMenu={vi.fn()}
       />,
     );
 
     expect(markup).toContain("workspace-top-menu-shell");
+    expect(markup).toContain('data-slot="dropdown-menu-trigger"');
   });
 
   /**
-   * Keeps the current destination label as the primary navigation control so switching views does
-   * not require a reach to the far edge of the shell.
+   * Keeps the current destination label as the primary navigation control while moving the menu to
+   * a stock shadcn dropdown pattern.
    */
   it("renders the active menu label as the trigger instead of a separate menu button", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceTopMenu
         activeMenu="projects"
-        isExpanded={false}
+        isOpen
+        onOpenChange={vi.fn()}
         onSelectMenu={vi.fn()}
-        onToggleMenu={vi.fn()}
       />,
     );
 
-    expect(markup).toContain('aria-controls="workspace-top-menu"');
+    expect(markup).toContain('data-slot="dropdown-menu-content"');
+    expect(markup).toContain("Navigate");
     expect(markup).toContain("Projects");
+    expect(markup).toContain("Current");
     expect(markup).not.toContain(">Menu<");
   });
 });


### PR DESCRIPTION
## Summary

- Resets all custom primitives (button, input, textarea, select, dialog, dropdown-menu, tooltip, badge, label, separator) to stock shadcn registry output
- Replaces the workspace shell (sidebar, collapsed rail, top menu) and global search with stock shadcn sidebar, collapsible, and command+dialog patterns
- Simplifies configuration onto stock shadcn accordion and card surfaces
- Standardizes task create-edit flows and tag selection on stock shadcn form, popover, and command patterns
- Converts project, initiative, archive, and thread surfaces to stock shadcn card compositions

Closes #27, closes #28, closes #29, closes #30, closes #31, closes #32

## Verification

- Lint: 0 errors
- Tests: 146/146 passing (33 test files)
- Build: full Next.js production build passes

## Test plan

- [ ] Verify task create/edit/delete flows work in inbox and project views
- [ ] Verify project and initiative CRUD workflows
- [ ] Verify global search keyboard navigation
- [ ] Verify theme selection in configuration
- [ ] Verify sidebar collapse/expand behavior
- [ ] Verify archive view renders completed tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)